### PR TITLE
Restrict keys to address records in the same canonical name.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -570,7 +570,7 @@ SHOULD be used but is likely to lead to connection failure.
  AAAA ? www.example.com.provider-A.com
      -> AAAA 2001:DB8::AAAA
  TXT ? _esni.www.example.com.provider-B.com
-     -> ".. KEY FOR B.."
+     -> "... KEY FOR B ..."
 ~~~~
 
 The client determines the canonical names for the www.example.com TXT

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -579,7 +579,7 @@ TXT record that matches the canonical address record it already has.
 
 ~~~~
     TXT ? _esni.www.example.com.provider-A.com
-        -> ".. KEY FOR A.."
+        -> "... KEY FOR A ..."
 ~~~~
 
 ## Misconfiguration

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -550,7 +550,7 @@ different providers which in turn will cause connection failures.
 
 In order to prevent this failure the client confirms that the two
 records being used share the same canonical provenance. Specifically,
-the client MUST confirm that the unprefixed (i.e. lacking the
+the client MUST confirm that the unprefixed (i.e., lacking the
 _esni. prefix) canonical name of the TXT record matches the canonical
 name of the address record.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -533,7 +533,7 @@ apply, as detailed below.
 ## Load Balancing Multiple Independent Providers {#multi-cdn}
 
 The DNS is used to independently transfer two linked pieces of
-informaton to implement ESNI. The server is identified through DNS
+information to implement ESNI. The server is identified through DNS
 address records and the server's ESNI configuration is specified in a TXT
 record that is transported separately. {{publishing-key}} requires
 that these records are coordinated.


### PR DESCRIPTION
fixes #35 

this would be a bit cleaner if we got rid of the prefix.. which I think we ought to do as well but is separable.