### PR TITLE
Add CertificateVerify to padding recommendation

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -506,11 +506,13 @@ messages, but just blindly forwards them.
 
 A server operating in Shared Mode uses PaddedServerNameList.sni as
 if it were the "server_name" extension to finish the handshake. It
-SHOULD pad the Certificate message, via padding at the record layer,
-such that its length equals the size of the largest possible Certificate
-(message) covered by the same ESNI key. Moreover, the server MUST
-include the "encrypted_server_name" extension in EncryptedExtensions,
-and the value of this extension MUST match PaddedServerNameList.nonce.
+SHOULD pad at least the Certificate and CertificateVerify ahnshake 
+messages, via padding at the record layer, so that differences between 
+different server_name instances (i.e. certificate or signature size) 
+covered by the same ESNI key are not apparent on the network. Moreover, 
+the server MUST include the "encrypted_server_name" extension in 
+EncryptedExtensions, and the value of this extension MUST match 
+PaddedServerNameList.nonce.
 
 ## Split Mode Server Behavior {#backend-server-behavior}
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -506,10 +506,10 @@ messages, but just blindly forwards them.
 
 A server operating in Shared Mode uses PaddedServerNameList.sni as
 if it were the "server_name" extension to finish the handshake. It
-SHOULD pad at least the Certificate and CertificateVerify ahnshake 
+SHOULD pad at least the Certificate and CertificateVerify handshake 
 messages, via padding at the record layer, so that differences between 
 different server_name instances (i.e. certificate or signature size) 
-covered by the same ESNI key are not apparent on the network. Moreover, 
+covered by the same ESNI key are not apparent on the wire. Moreover, 
 the server MUST include the "encrypted_server_name" extension in 
 EncryptedExtensions, and the value of this extension MUST match 
 PaddedServerNameList.nonce.


### PR DESCRIPTION
Also takes out the "longest length" part of the SHOULD since (as Viktor pointed out) a server might not always know that and it can change due to CA or other PKI changes that might lead to errors in some scenarios. (E.g. CA adds new extension thereby causing a cert to be longer than what the TLS server thinks is longest.)