### PR TITLE
Swap version[4] and checksum, so the latter covers the entire struct.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -187,8 +187,8 @@ structure, defined below.
     } KeyShareEntry;
 
     struct {
-        uint16 version;
         uint8 checksum[4];
+        uint16 version;
         KeyShareEntry keys<4..2^16-1>;
         CipherSuite cipher_suites<2..2^16-2>;
         uint16 padded_length;


### PR DESCRIPTION
Addresses #119, and we want the checksum to cover the entire struct by definition. 