### PR TITLE
Remove checksum in favor of record_digest and retry mechanism.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -210,7 +210,6 @@ SNI Encryption keys can be published using the following ESNIRecord structure.
 
     struct {
         uint16 version;
-        uint8 checksum[4];
         opaque public_name<1..2^16-1>;
         KeyShareEntry keys<4..2^16-1>;
         CipherSuite cipher_suites<2..2^16-2>;
@@ -246,11 +245,6 @@ version
 SHALL be 0xff02. Clients MUST ignore any ESNIKeys structure with a
 version they do not understand.
 [[NOTE: This means that the RFC will presumably have a nonzero value.]]
-
-checksum
-: The first four (4) octets of the SHA-256 message digest {{RFC6234}}
-of the ESNIKeys structure. For the purpose of computing the checksum, the
-value of the "checksum" field MUST be set to zero.
 
 public_name
 : The non-empty name of the entity trusted to update these encryption keys.
@@ -301,9 +295,9 @@ example.com, the ESNI Resource Record might be:
 example.com. 60S IN ESNI "..." "..."
 ~~~
 
-The "checksum" field provides protection against transmission errors,
-including those caused by intermediaries such as a DNS proxy running on a
-home router.
+In the event that ESNIKeys is corrupt in transit or otherwise invalid, servers
+will initiate the retry mechanism described in {{server-behavior}} and deliver
+valid ESNIKeys to clients.
 
 Note that the length of the ESNIRecord structure MUST NOT exceed 2^16 - 1, as the
 RDLENGTH is only 16 bits {{RFC1035}}.
@@ -419,7 +413,7 @@ used to derive the ESNI key.
 
 record_digest
 : A cryptographic hash of the ESNIKeys structure from which the ESNI
-key was obtained, i.e., from the first byte of "checksum" to the end
+key was obtained, i.e., from the first byte of "version" to the end
 of the structure.  This hash is computed using the hash function
 associated with `suite`.
 


### PR DESCRIPTION
The checksum seems to add little value with the retry mechanism and record_digest. I think we should remove it. See #64 for some context.