### PR TITLE
Add reference to RFC8446 for TLS notation.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -104,8 +104,8 @@ already tell from the IP address.
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
 "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this
 document are to be interpreted as described in BCP 14 {{RFC2119}} {{!RFC8174}}
-when, and only when, they appear in all capitals, as shown here.
-
+when, and only when, they appear in all capitals, as shown here. All TLS notation 
+comes from {{RFC8446}}; Section 3. 
 
 # Overview
 


### PR DESCRIPTION
Fixes #160.