### PR TITLE
Clarify server HRR behavior, and add label-based workaround for nonce-reuse

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -648,10 +648,10 @@ and the client can send a second updated ClientHello per the rules in
 on the (possibly updated) KeyShareClientHello, i.e,,
 ClientEncryptedSNI.suite, ClientEncryptedSNI.key_share, and
 ClientEncryptedSNI.record_digest, MUST NOT change across ClientHello messages.
-Moreover, ClientESNIInner.nonce and ClientESNIInner.realSNI MUST not change
-across ClientHello messages. Informally, the values of all unencrypted extension
-information, as well as the inner extension plaintext, must be consistent between
-the first and second ClientHello messages.
+Moreover, ClientESNIInner MUST not change across ClientHello messages.
+Informally, the values of all unencrypted extension information, as well as
+the inner extension plaintext, must be consistent between the first and
+second ClientHello messages.
 
 ### Authenticating for the public name {#auth-public-name}
 
@@ -779,9 +779,10 @@ the latter case, it does not make any changes to the TLS
 messages, but just blindly forwards them.
 
 If the ClientHello is the result of a HelloRetryRequest, servers MUST
-abort the connection with an "illegal_parameter" alert if the decrypted
-ClientESNIInner from the second ClientHello does not match that
-of the first ClientHello.
+abort the connection with an "illegal_parameter" alert if any of the
+ClientEncryptedSNI.suite, ClientEncryptedSNI.key_share, ClientEncryptedSNI.record_digest,
+or decrypted ClientESNIInner values from the second ClientHello do not
+match that of the first ClientHello.
 
 ## Shared Mode Server Behavior
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -242,7 +242,7 @@ The ESNIKeys structure contains the following fields:
 
 version
 : The version of the structure. For this specification, that value
-SHALL be 0xff02. Clients MUST ignore any ESNIKeys structure with a
+SHALL be 0xff03. Clients MUST ignore any ESNIKeys structure with a
 version they do not understand.
 [[NOTE: This means that the RFC will presumably have a nonzero value.]]
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -765,7 +765,7 @@ MUST abort the connection with a "decrypt_error" alert.
 If the decrypted value's length is different from
 the advertised ESNIKeys.padded_length or the padding consists of
 any value other than 0, then the server MUST abort the
-connection with an illegal_parameter alert. Otherwise, the
+connection with an "illegal_parameter" alert. Otherwise, the
 server uses the PaddedServerNameList.sni value as if it were
 the "server_name" extension. Any actual "server_name" extension is
 ignored, which also means the server MUST NOT send the "server_name"
@@ -779,7 +779,7 @@ the latter case, it does not make any changes to the TLS
 messages, but just blindly forwards them.
 
 If the ClientHello is the result of a HelloRetryRequest, servers MUST
-abort the connection with an illegal_parameter alert if the decrypted
+abort the connection with an "illegal_parameter" alert if the decrypted
 ClientESNIInner from the second ClientHello does not match that
 of the first ClientHello.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -508,6 +508,10 @@ KeyLabel = "hrr esni key" and IVLabel = "hrr esni iv". (This label variance
 is done to prevent nonce re-use since the client's ESNI key share, and
 thus the value of Zx, does not change across ClientHello retries.)
 
+[[TODO: label swapping fixes a bug in the spec, though this may not be
+the best way to deal with HRR. See https://github.com/tlswg/draft-ietf-tls-esni/issues/121
+and https://github.com/tlswg/draft-ietf-tls-esni/pull/170 for more details.]]
+
 ~~~
    struct {
        opaque record_digest<0..2^16-1>;


### PR DESCRIPTION
Since the client's ESNI key share doesn't change across CHs in response to a HRR, the same AEAD IV would be used to encrypt/decrypt two different messages. This is an attempt to fix that, while also specifying the server-side HRR behavior. (Basically, check that the ESNI contents have not changed.)