### PR TITLE
Drop fixed key_share requirement to avoid nonce reuse and better align with HPKE

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -242,7 +242,7 @@ The ESNIKeys structure contains the following fields:
 
 version
 : The version of the structure. For this specification, that value
-SHALL be 0xff02. Clients MUST ignore any ESNIKeys structure with a
+SHALL be 0xff03. Clients MUST ignore any ESNIKeys structure with a
 version they do not understand.
 [[NOTE: This means that the RFC will presumably have a nonzero value.]]
 


### PR DESCRIPTION
This is an alternative to #168, wherein we use fresh DH keys each time and avoid changing the key/iv derivation labels across CH messages.