### PR TITLE
Add description about "cipher suites" via an ESNIKeys extension

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -258,6 +258,9 @@ keys
 : The list of keys which can be used by the client to encrypt the SNI.
 Every key being listed MUST belong to a different group.
 
+cipher_suites
+: The list of cipher suites which can be used by the client to encrypt the SNI.
+
 padded_length
 The length to pad the ServerNameList value to prior to encryption.
 This value SHOULD be set to the largest ServerNameList the server

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -262,7 +262,7 @@ cipher_suites
 : The list of cipher suites which can be used by the client to encrypt the SNI.
 
 padded_length
-The length to pad the ServerNameList value to prior to encryption.
+: The length to pad the ServerNameList value to prior to encryption.
 This value SHOULD be set to the largest ServerNameList the server
 expects to support rounded up the nearest multiple of 16. If the
 server supports arbitrary wildcard names, it SHOULD set this value to


### PR DESCRIPTION
Add missing description for cipher_suites and add colon symbol to padded_length