### PR TITLE
Flatten ESNI negotiation mechanisms

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -174,7 +174,7 @@ it to the backend server (in Split Mode).
 # Encrypted SNI Configuration {#esni-configuration}
 
 SNI Encryption configuration information is conveyed with the following
-ESNIConfig structure.
+ESNIConfigs structure.
 
 ~~~~
     // Copied from TLS 1.3
@@ -195,7 +195,13 @@ ESNIConfig structure.
         uint16 padded_length;
         Extension extensions<0..2^16-1>;
     } ESNIConfigContents;
+
+    ESNIConfig ESNIConfigs<1..2^16-1>;
 ~~~~
+
+The ESNIConfigs structure contains one or more ESNIConfig structures in
+decreasing order of preference. This allows a server to support multiple
+versions of ESNI and multiple sets of ESNI extensions.
 
 The ESNIConfig structure contains the following fields:
 
@@ -221,7 +227,7 @@ keys
 Every key being listed MUST belong to a different group.
 
 padded_length
-The length to pad the ServerNameList value to prior to encryption.
+: The length to pad the ServerNameList value to prior to encryption.
 This value SHOULD be set to the largest ServerNameList the server
 expects to support rounded up the nearest multiple of 16. If the
 server supports arbitrary wildcard names, it SHOULD set this value to
@@ -299,7 +305,7 @@ structure:
        ServerESNIResponseType response_type;
        select (response_type) {
            case esni_accept:        uint8 nonce[16];
-           case esni_retry_request: ESNIConfig retry_keys<1..2^16-1>;
+           case esni_retry_request: ESNIConfigs retry_configs;
        }
    } ServerEncryptedSNI;
 ~~~
@@ -311,7 +317,7 @@ response_type
 nonce
 : The contents of ClientESNIInner.nonce. (See {{client-behavior}}.)
 
-retry_keys
+retry_configs
 : One or more ESNIConfig structures containing the keys that the client should use on
 subsequent connections to encrypt the ClientESNIInner structure.
 
@@ -336,8 +342,10 @@ to client and server session states.
 
 ### Sending an encrypted SNI {#send-esni}
 
-In order to send an encrypted SNI, the client MUST first select one of
-the server ESNIKeyShareEntry values and generate an (EC)DHE share in the
+In order to send an encrypted SNI, the client MUST first select one of the
+ESNIConfig values in the ESNIConfigs structure which it is able to process (see
+{{esni-configuration}}). It MUST then select one of the KeyShareEntry values in the
+ESNIConfig and generate an (EC)DHE share in the
 matching group. This share will then be sent to the server in the
 "encrypted_server_name" extension and used to derive the SNI encryption key. It does not affect the
 (EC)DHE shared secret used in the TLS key schedule. The client MUST also select
@@ -443,7 +451,7 @@ extension in a Client Hello (Section 4.2.8 of {{!RFC8446}})). Including
 KeyShareClientHello in the AAD of AEAD-Encrypt binds the ClientEncryptedSNI
 value to the ClientHello and prevents cut-and-paste attacks.
 
-Note: future extensions may end up reusing the server's ESNIKeyShareEntry
+Note: future extensions may end up reusing the server's KeyShareEntry
 for other purposes within the same message (e.g., encrypting other
 values). Those usages MUST have their own HKDF labels to avoid
 reuse.
@@ -565,9 +573,10 @@ error code.
 
 ### GREASE extensions {#grease-extensions}
 
-If the client attempts to connect to a server and does not have an ESNIConfig
-structure available for the server, it SHOULD send a GREASE
-{{I-D.ietf-tls-grease}} "encrypted_server_name" extension as follows:
+If the client attempts to connect to a server and does not have an ESNIConfigs
+structure available for the server or was unable to select an appropriate
+ESNIConfig value, it SHOULD send a GREASE {{I-D.ietf-tls-grease}}
+"encrypted_server_name" extension as follows:
 
 - Select a supported cipher suite, named group, and padded_length
   value. The padded_length value SHOULD be 260 (sum of the maximum DNS name
@@ -624,10 +633,8 @@ with the following added behavior:
 
 - It MUST include the "encrypted_server_name" extension in
   EncryptedExtensions message with the "response_type" field set to
-  "esni_retry_requested" and the "retry_keys" field set to one or more
-  ESNIConfig structures with up-to-date keys. Servers MAY supply multiple
-  ESNIConfig values of different versions. This allows a server to support
-  multiple versions at once.
+  "esni_retry_requested" and the "retry_configs" field set to an up-to-date
+  ESNIConfigs structure.
 
 - The server MUST ignore all PSK identities in the ClientHello which correspond
   to ESNI PSKs. ESNI PSKs offered by the client are associated with the ESNI
@@ -899,7 +906,7 @@ from a trusted Recursive Resolver, spoofing a server operating in Split Mode
 is not possible. See {{cleartext-dns}} for more details regarding cleartext
 DNS.
 
-Authenticating the ESNIConfig structure naturally authenticates the
+Authenticating the ESNIConfigs structure naturally authenticates the
 included public name. This also authenticates any retry signals
 from the server because the client validates the server
 certificate against the public name before retrying.


### PR DESCRIPTION
[This was split out of #199 as the possibly more controversial idea. It's a simplification but does make configs larger. Also it sits on top of #198 and #200. Ignore the first two comments to look at it in isolation.]

We have two layers of parameter negotiation. Multiple KeyShareEntry values in an ESNIConfig, and multiple ESNIConfig values in an ESNIConfigs. We only need one mechanism, so store only one KeyShareEntry in an ESNIConfig.

This simplifies representing client and server configuration, which simplies implementation internals as well as interchange formats. Right now, on the server, configuration has two layers of lists, something like list(tuple(ESNIConfig, list(PrivateKey))). Now the server maintains list(tuple(ESNIConfig, PrivateKey)).

Note also that draft-farrell-tls-pemesni-00 has this oddity around what to do if the ESNIKeys contains multiple keys. This is particularly a nuisance because a single standalone PRIVATE KEY / ESNIKEY pair is not usable because the server has committed to answering to *all* keys in the ESNIKeys. The server must consume multiple PEM files, match up the ESNIKeyses, and then assert that it has a complete set.

The downside is that, in the likely case that the server only supports one version and one set of extensions, the non-key ESNI config bits (notably the public name; the rest is small) are repeated for every named group. However, the public name should not be that large and servers should only need one or two groups (see https://www.imperialviolet.org/2016/05/16/agility.html).