### PR TITLE
Align client GREASE section with ClientEncryptedCH definition.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -624,10 +624,7 @@ If the client attempts to connect to a server and does not have an ECHOConfig
 structure available for the server, it SHOULD send a GREASE
 {{I-D.ietf-tls-grease}} "encrypted_client_hello" extension as follows:
 
-- Select a supported cipher suite, named group, and padded_length
-  value. The padded_length value SHOULD be 260 (sum of the maximum DNS name
-  length and TLS encoding overhead) or a multiple of 16 less than 260.
-  Set the "suite" field  to the selected cipher suite. These selections
+- Set the "suite" field  to a supported cipher suite. These selections
   SHOULD vary to exercise all supported configurations, but MAY be held constant
   for successive connections to the same server in the same session.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -624,7 +624,7 @@ If the client attempts to connect to a server and does not have an ECHOConfig
 structure available for the server, it SHOULD send a GREASE
 {{I-D.ietf-tls-grease}} "encrypted_client_hello" extension as follows:
 
-- Set the "suite" field  to a supported cipher suite. These selections
+- Set the "suite" field  to a supported cipher suite. The selection
   SHOULD vary to exercise all supported configurations, but MAY be held constant
   for successive connections to the same server in the same session.
 
@@ -635,8 +635,7 @@ structure available for the server, it SHOULD send a GREASE
 - Set the "enc" field to a randomly-generated valid encapsulated public key
   output by the HPKE KEM.
 
-- Set the "encrypted_ch" field to a randomly-generated string of padded_length
-  bytes.
+- Set the "encrypted_ch" field to a randomly-generated string of [TODO] bytes.
 
 If the server sends an "encrypted_client_hello" extension, the client
 MUST check the extension syntactically and abort the connection with a

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -631,15 +631,15 @@ structure available for the server, it SHOULD send a GREASE
   SHOULD vary to exercise all supported configurations, but MAY be held constant
   for successive connections to the same server in the same session.
 
-- Set the "enc" field to a randomly-generated valid encapsulated public key
-  output by the HPKE KEM.
-
 - Set the "record_digest" field to a randomly-generated string of hash_length
   bytes, where hash_length is the length of the hash function associated with
   the chosen cipher suite.
 
-- Set the "encrypted_client_hello" field to a randomly-generated string of
-  [TODO] bytes.
+- Set the "enc" field to a randomly-generated valid encapsulated public key
+  output by the HPKE KEM.
+
+- Set the "encrypted_ch" field to a randomly-generated string of padded_length
+  bytes.
 
 If the server sends an "encrypted_client_hello" extension, the client
 MUST check the extension syntactically and abort the connection with a


### PR DESCRIPTION
Also define the length of the randomly-generated "encrypted_ch" field.