### PR TITLE
padding scheme text

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -460,7 +460,7 @@ For each field in the inner ClientHello, clients need to determine how much to
 pad given the semantics of that field.  For example, if a client can propose
 various ALPN values, it could add padding to round up to the longest of those.
 
-For most fields in a ClientHello this can be determined without server help.
+The target padding length of most ClientHello extensions can be determined without server help.
 For the server_name, however, if ECHOConfig.maximum_name_length is longer than
 the actual server_name then clients SHOULD add padding to make up that
 difference. If the maximum_name_length is zero or less than the length of the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -204,7 +204,7 @@ following ECHOConfigs structure.
         HkpeKemId kem_id;
         CipherSuite cipher_suites<2..2^16-2>;
 
-        uint16 maximum_name_length;
+        uint16 minimum_inner_length;
         Extension extensions<0..2^16-1>;
     } ECHOConfigContents;
 
@@ -254,10 +254,11 @@ cipher_suites
 See {{hpke-map}} for information on how a cipher suite maps to corresponding
 HPKE algorithm identifiers.
 
-maximum_name_length
-:  the largest name the server expects to support. If the server supports arbitrary
-wildcard names, it SHOULD set this value to 256. Clients SHOULD reject ESNIConfig as
-invalid if maximum_name_length is greater than 256.
+minimum_inner_length
+:  The minimum (encoded) length ClientHelloInner recommended by the server.
+Sending a ClientHelloInner that is shorter than this will likely stand out.
+Clients can use a padding extension within the ClientHelloInner to ensure
+the plaintext is at leat this long.
 
 extensions
 : A list of extensions that the client can take into consideration when
@@ -444,10 +445,33 @@ values, ClientHelloInner MUST also contain:
  - an "echo_nonce" extension
  - TLS padding {{!RFC7685}}
 
-Padding SHOULD be P = L - D bytes, where
+An encoded ClientHelloInner can be around 300 octets long, but variations in
+the length of the ciphertext version of that could defeat the entire purpose of
+ECHO, if for example those expose the chosen server_name field in the
+ClientHelloInner.  The padding ClientHello extension, if well used, can ensure
+that length information does not expose what is contained in the
+ClientHelloInner. Clients MUST add padding to the ClientHelloInner to try meet
+this requirement.
 
-- L = ECHOConfig.maximum_name_length, rounded up to the nearest multiple of 16
-- D = len(dns_name), where dns_name is the DNS name in the ClientHelloInner "server_name" extension
+Given that new extensions may be defined in future that contain sensitive
+length fields, we cannot describe all the ways in which length information
+could expose sensitive content. Implementers ought therefore be aware that they
+might have to change their padding scheme as the set of supported extensions
+changes. In addition to padding the ClientHelloInner, clients and servers MUST
+both pad all other handshake messages that have sensitive length fields. For
+example, if the client proposes ALPN values in the ClientHelloInner, the
+server-selected value will be returned in an EncryptedExtension, so that
+handshake message needs to be padded with TLS record layer padding. 
+
+One approach that may be relative safe and simple is once ECHO is in use:
+
+- When constructing the ClientHelloInner, use padding bytes so that the length
+  of the plaintext erncoding of ClienHelloInner is greater than
+ECHOConfig.minimum_inner_length and is a multiple of 16
+- Both clients and servers pad all handshake messages so that plaintexts are a
+  multiple of 16 octets long.
+- Clients or servers MAY send additional padding bytes. This MUST NOT be
+  treated as an error.
 
 When offering an encrypted ClientHello, the client MUST NOT offer to resume any
 non-ECHO PSKs. It additionally MUST NOT offer to resume any sessions for TLS 1.2

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -466,7 +466,7 @@ handshake message needs to be padded with TLS record layer padding.
 One approach that may be relative safe and simple is once ECHO is in use:
 
 - When constructing the ClientHelloInner, use padding bytes so that the length
-  of the plaintext erncoding of ClienHelloInner is greater than
+  of the plaintext encoding of ClienHelloInner is greater than
 ECHOConfig.minimum_inner_length and is a multiple of 16
 - Both clients and servers pad all handshake messages so that plaintexts are a
   multiple of 16 octets long.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -256,10 +256,10 @@ HPKE algorithm identifiers.
 
 maximum_name_length  
 : The largest name the server expects to support, if known.
-If this value is not known (e.g. if wildcard names are in use, or names can be
-added or removed from the anonymity set during the lifetime of a particular
-resource record value), then this value can be set to zero, in which case
-clients SHOULD use the inner ClientHello padding scheme described below.
+If this value is not known it can be set to zero, in which case clients SHOULD
+use the inner ClientHello padding scheme described below.  That could happen if
+wildcard names are in use, or if names can be added or removed from the
+anonymity set during the lifetime of a particular resource record value.
 
 extensions
 : A list of extensions that the client can take into consideration when
@@ -969,12 +969,12 @@ SNI uniformly?]]
 
 ## Padding
 
-Variations in the length of the ciphertext version of the ClientHelloInner
-could defeat the purpose of ECHO, if those expose the chosen server_name field
-in the ClientHelloInner. The padding ClientHello extension, if well used, can
-ensure that length information does not expose what is contained in the
-ClientHelloInner. Clients SHOULD add padding to the ClientHelloInner to meet this
-requirement.
+Variations in the length of the ClientHelloInner ciphertext could defeat the
+purpose of ECHO, if those expose the chosen server_name field in the
+ClientHelloInner. The padding ClientHello extension, if well used, can ensure
+that length information does not expose what is contained in the
+ClientHelloInner. Clients SHOULD add padding to the ClientHelloInner to meet
+this requirement.
 
 [[TODO: once the padding scheme is final, revisit the above.]]
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -476,11 +476,11 @@ all per-extension padding values, rounded up to the nearest multiple of 32.
 (This additional rounding step aims to hide variance across different client
 implementations.)
 
-In addition to padding the ClientHelloInner, clients and servers will also need
+In addition to padding ClientHelloInner, clients and servers will also need
 to pad all other handshake messages that have sensitive-length fields. For
-example, if a client proposes ALPN values in the ClientHelloInner, the
+example, if a client proposes ALPN values in ClientHelloInner, the
 server-selected value will be returned in an EncryptedExtension, so that
-handshake message also needs to be padded using TLS record layer padding. 
+handshake message also needs to be padded using TLS record layer padding.
 
 When offering an encrypted ClientHello, the client MUST NOT offer to resume any
 non-ECHO PSKs. It additionally MUST NOT offer to resume any sessions for TLS 1.2

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -461,11 +461,14 @@ pad given the semantics of that field.  For example, if a client can propose
 various ALPN values, it could add padding to round up to the longest of those.
 
 The target padding length of most ClientHello extensions can be determined without server help.
-For the server_name, however, if ECHOConfig.maximum_name_length is longer than
-the actual server_name then clients SHOULD add padding to make up that
-difference. If the maximum_name_length is zero or less than the length of the
-actual server_name then round the server_name up to a multiple of 32 octets and
-randomly add another 32 octets 50% of the time and then include that amount
+However, the "server_name" extension could benefit from server input (ECHOConfig.maximum_name_length). 
+Clients SHOULD compute the padding for this extension as follows:
+
+1. If ECHOConfig.maximum_name_length is longer than the actual server_name then 
+clients SHOULD add padding to make up that difference.
+2. Otherwise, if ECHOConfig.maximum_name_length is zero or less than the length 
+of the actual server_name then round the server_name up to a multiple of 32 octets 
+and randomly add another 32 octets 50% of the time and then include that amount
 of additional padding.
 
 Sum all the padding together, then in order to reduce entropy across different

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -257,7 +257,7 @@ HPKE algorithm identifiers.
 maximum_name_length  
 : The largest name the server expects to support, if known.
 If this value is not known (e.g. if wildcard names are in use, or names can be
-added or removed from tne anonymity set during the lifetime of a particular
+added or removed from the anonymity set during the lifetime of a particular
 resource record value), then this value can be set to zero, in which case
 clients SHOULD use the inner ClientHello padding scheme described below.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -471,9 +471,10 @@ of the actual server_name then round the server_name up to a multiple of 32 octe
 and randomly add another 32 octets 50% of the time and then include that amount
 of additional padding.
 
-Sum all the padding together, then in order to reduce entropy across different
-client implementationss, round up so that the inner ClientHello encoding length 
-is a multiple of 32.
+The amount of padding applied to the ClientHello is then computed as the sum of 
+all per-extension padding values, rounded up to the nearest multiple of 32. 
+(This additional rounding step aims to hide variance across different client
+implementations.)
 
 In addition to padding the ClientHelloInner, clients and servers will also need
 to pad all other handshake messages that have sensitive-length fields. For

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -258,7 +258,7 @@ minimum_inner_length
 :  The minimum (encoded) length ClientHelloInner recommended by the server.
 Sending a ClientHelloInner that is shorter than this will likely stand out.
 Clients can use a padding extension within the ClientHelloInner to ensure
-the plaintext is at leat this long.
+the plaintext is at least this long.
 
 extensions
 : A list of extensions that the client can take into consideration when

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -453,11 +453,8 @@ ensure that length information does not expose what is contained in the
 ClientHelloInner. Clients SHOULD add padding to the ClientHelloInner to meet this
 requirement.
 
-Given that extensions could be defined in the future that reveal sensitive information
-through their length, we cannot describe all the ways in which length information
-could expose sensitive content. Implementers ought therefore be aware that they
-might have to change their padding scheme as the set of supported extensions
-changes. 
+Future extensions could reveal sensitive information through their length. Consequently, 
+padding should be flexible and support arbitrary extension changes. 
 
 For each field in the inner ClientHello, clients need to determine how much to
 pad given the semantics of that field.  For example, if a client can propose

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -453,8 +453,8 @@ that length information does not expose what is contained in the
 ClientHelloInner. Clients MUST add padding to the ClientHelloInner to try meet
 this requirement.
 
-Given that new extensions may be defined in future that contain sensitive
-length fields, we cannot describe all the ways in which length information
+Given that extensions could be defined in the future that reveal sensitive information
+through their length, we cannot describe all the ways in which length information
 could expose sensitive content. Implementers ought therefore be aware that they
 might have to change their padding scheme as the set of supported extensions
 changes. In addition to padding the ClientHelloInner, clients and servers MUST


### PR DESCRIPTION
I've tried to capture what I think is a reasonable way to handle padding now we've changed from ESNI->ECHO.  If we could do something like this, that'd be better than what's in -06.

Note that I'd be even happier if we entirely eliminated ECHOConfig.minimum_inner_length - I don't think it actually adds any value and it represents yet another way to get a configuration wrong.  