### PR TITLE
Bind CHOuter to CHInner

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -718,9 +718,12 @@ Otherwise, if there is no "echo_nonce" extension, or if its value does not
 match the derived echo_nonce, the server MUST abort the connection with a
 "decrypt_error" alert. Next, the server MUST scan ClientHelloInner for any
 "outer_extension" extensions and substitute their values with the values in
-ClientHelloOuter. It MUST first verify that the hash found in the extension
-matches the hash of the extension to be interpolated in and if it does not,
-abort the connections with a "decrypt_error" alert.
+ClientHelloOuter.
+
+If ClientHelloInner contains a resumption PSK binder, the server SHOULD process it
+as per the rules in {{!RFC8446}}. Note that this requires servers process more than
+one binder when resuming an ECHO connection: one in ClientHelloOuter and another
+in ClientHelloInner.
 
 Upon determining the true SNI, the client-facing server then either
 serves the connection directly (if in Shared Mode), in which case

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -702,12 +702,10 @@ outer_binder_identity = context.Export("tls13-echo-binder-identity", TODO)
 outer_binder_key = context.Export("tls13-echo-binder-key", 16)
 ~~~
 
-If there is no PSK binder in ClientHelloOuter, or if there is no PSK identity matching
-outer_binder_identity, the server ignores the "encrypted_client_hello" extension.
-Otherwise, it attempts to verify the PSK binder using outer_binder_key. If verification
-fails, the server MUST abort the connection with a "decrypt_error" alert.
-If verification succeeds, the server then attempts to decrypt the "encrypted_client_hello"
-extension value as follows:
+If there is no PSK binder in ClientHelloOuter, there is no PSK identity matching
+outer_binder_identity, or if binder verification fails, the server ignores the
+"encrypted_client_hello" extension. Otherwise, the server then attempts to
+decrypt the "encrypted_client_hello" extension value as follows:
 
 ~~~
 ClientHelloInner = context.Open("", ClientEncryptedCH.encrypted_ch)
@@ -715,15 +713,14 @@ echo_nonce = context.Export("tls13-echo-nonce", 16)
 echo_hrr_key = context.Export("tls13-echo-hrr-key", 16)
 ~~~
 
-If decryption fails, the server MUST abort the connection with
-a "decrypt_error" alert. Moreover, if there is no "echo_nonce"
-extension, or if its value does not match the derived echo_nonce,
-the server MUST abort the connection with a "decrypt_error" alert.
-Next, the server MUST scan ClientHelloInner for any "outer_extension"
-extensions and substitute their values with the values in ClientHelloOuter.
-It MUST first verify that the hash found in the extension matches the hash
-of the extension to be interpolated in and if it does not, abort the connections
-with a "decrypt_error" alert.
+If decryption fails, the server ignores the "encrypted_client_hello" extension.
+Otherwise, if there is no "echo_nonce" extension, or if its value does not
+match the derived echo_nonce, the server MUST abort the connection with a
+"decrypt_error" alert. Next, the server MUST scan ClientHelloInner for any
+"outer_extension" extensions and substitute their values with the values in
+ClientHelloOuter. It MUST first verify that the hash found in the extension
+matches the hash of the extension to be interpolated in and if it does not,
+abort the connections with a "decrypt_error" alert.
 
 Upon determining the true SNI, the client-facing server then either
 serves the connection directly (if in Shared Mode), in which case

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -380,7 +380,6 @@ the impact of duplicated extensions, the client may use the
 
    struct {
        ExtensionType outer_extensions<2..254>;
-       uint8 hash<32..255>;
    } OuterExtensions;
 ~~~~
 
@@ -392,18 +391,14 @@ ClientHelloInner.
 When sending ClientHello, the client first computes ClientHelloInner,
 including any PSK binders, and then MAY substitute extensions which
 it knows will be duplicated in ClientHelloOuter. To do so, the client
-computes a hash H of the entire ClientHelloInner message with the same
-hash as for the KDF used to encrypt ClienHelloInner. Then, the client
 removes and and replaces extensions from ClientHelloInner with a single
 "outer_extensions" extension. The list of outer_extensions include those
 which were removed from ClientHelloInner, in the order in which they were
-removed. The hash contains the full ClientHelloInner hash H computed above.
+removed.
 
 This process is reversed by client-facing servers upon receipt. Specifically,
 the server replaces the "outer_extensions" with extensions contained in
-ClientHelloOuter. The server then computes a hash H' of the reconstructed
-ClientHelloInner. If H' does not equal OuterExtensions.hash, the server aborts
-the connection with an "illegal_parameter" alert.
+ClientHelloOuter.
 
 Clients SHOULD only use this mechanism for extensions which are
 large. All other extensions SHOULD appear in both ClientHelloInner

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -391,7 +391,7 @@ ClientHelloInner.
 When sending ClientHello, the client first computes ClientHelloInner,
 including any PSK binders, and then MAY substitute extensions which
 it knows will be duplicated in ClientHelloOuter. To do so, the client
-removes and and replaces extensions from ClientHelloInner with a single
+removes and replaces extensions from ClientHelloInner with a single
 "outer_extensions" extension. The list of outer_extensions include those
 which were removed from ClientHelloInner, in the order in which they were
 removed.


### PR DESCRIPTION
This makes it so that changes to the outer CH do not affect the inner. If anything does change that might muck with the binder or decryption, then ECHO is ignored. (This should help GREASE.)