### PR TITLE
Suggest size of GREASE encrypted_ch extension value.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -260,7 +260,7 @@ anonymity set during the lifetime of a particular resource record value.
 extensions
 : A list of extensions that the client can take into consideration when
 generating a ClientHello message. The purpose of the field is to provide room
-for additional functionality in the future. See {{config-extensions}} for 
+for additional functionality in the future. See {{config-extensions}} for
 guidance on what type of extensions are appropriate for this structure.
 
 The format is defined in {{RFC8446}}, Section 4.2. The same interpretation rules
@@ -463,7 +463,8 @@ indicated above. In particular,
 - suite contains the client's chosen HpkeCipherSuite;
 - record_digest contains the digest of the corresponding ECHOConfig structure;
 - enc contains the encapsulated key as output by SetupBaseS; and
-- encrypted_ch contains the HPKE encapsulated key (enc) and the ClientHelloInner ciphertext (encrypted_ch_inner).
+- encrypted_ch contains the HPKE encapsulated key (enc) and the ClientHelloInner
+ciphertext (encrypted_ch_inner).
 
 The client MUST place the value of ECHOConfig.public_name in the
 ClientHelloOuter "server_name" extension. The ClientHelloOuter MUST NOT
@@ -655,7 +656,9 @@ structure available for the server, it SHOULD send a GREASE
 - Set the "enc" field to a randomly-generated valid encapsulated public key
   output by the HPKE KEM.
 
-- Set the "encrypted_ch" field to a randomly-generated string of [TODO] bytes.
+- Set the "encrypted_ch" field to a randomly-generated string of L bytes, where
+L is the size of the ClientHelloInner message the client would use given an
+ECHOConfig structure, padded according to {{padding}}.
 
 If the server sends an "encrypted_client_hello" extension, the client
 MUST check the extension syntactically and abort the connection with a
@@ -981,11 +984,11 @@ existing registry for Alerts (defined in {{!RFC8446}}), with the
 # ECHOConfig Extension Guidance {#config-extensions}
 
 Any future information or hints that influence the outer ClientHello SHOULD be
-specified as ECHOConfig extensions, or in an entirely new version of ECHOConfig. 
-This is primarily because the outer ClientHello exists only in support of ECHO. 
-Namely, it is both an envelope for the encrypted inner ClientHello and enabler for 
-authenticated key mismatch signals (see {{server-behavior}}). In contrast, the inner 
-ClientHello is the true ClientHello used upon ECHO negotiation. 
+specified as ECHOConfig extensions, or in an entirely new version of ECHOConfig.
+This is primarily because the outer ClientHello exists only in support of ECHO.
+Namely, it is both an envelope for the encrypted inner ClientHello and enabler for
+authenticated key mismatch signals (see {{server-behavior}}). In contrast, the inner
+ClientHello is the true ClientHello used upon ECHO negotiation.
 
 --- back
 


### PR DESCRIPTION
This assumes the GREASE threat model is a misbehaving and lazy middlebox. That is, we aim to prevent ossification. It does nothing more to prevent an active attacker from learning whether or not a particular connection used GREASE. (That problem is probably better suited to something like MASQUE.)

cc @davidben @ekr @martinthomson