### PR TITLE
Specify encrypted_client_hello and outer_extension codepoints.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -282,7 +282,7 @@ extension, defined as follows:
 
 ~~~
    enum {
-       encrypted_client_hello(0xffce), (65535)
+       encrypted_client_hello(57), (65535)
    } ExtensionType;
 ~~~
 
@@ -346,7 +346,7 @@ ClientHello. This extension is defined as follows:
 
 ~~~
    enum {
-       ech_nonce(0xffce), (65535)
+       ech_nonce(57), (65535)
    } ExtensionType;
 
    struct {
@@ -376,7 +376,7 @@ the impact of duplicated extensions, the client may use the
 
 ~~~
    enum {
-       outer_extension(0xffcd), (65535)
+       outer_extension(58), (65535)
    } ExtensionType;
 
    struct {
@@ -1109,9 +1109,9 @@ envelope.
 IANA is requested to create the following two entries in the existing registry
 for ExtensionType (defined in {{!RFC8446}}):
 
-1. encrypted_client_hello(0xffce), with "TLS 1.3" column values being set to
+1. encrypted_client_hello(57), with "TLS 1.3" column values being set to
 "CH, EE", and "Recommended" column being set to "Yes".
-2. outer_extension(0xffcd), with the "TLS 1.3" column values being set to
+2. outer_extension(58), with the "TLS 1.3" column values being set to
 "CH", and "Recommended" column being set to "Yes".
 
 ## Update of the TLS Alert Registry

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -210,7 +210,7 @@ following ECHConfigs structure.
         uint16 version;
         uint16 length;
         select (ECHConfig.version) {
-          case 0xff03: ECHConfigContents;
+          case 0xff07: ECHConfigContents;
         }
     } ECHConfig;
 
@@ -225,7 +225,7 @@ The ECHConfig structure contains the following fields:
 
 version
 : The version of the structure. For this specification, that value
-SHALL be 0xff03. Clients MUST ignore any ECHConfig structure with a
+SHALL be 0xff07. Clients MUST ignore any ECHConfig structure with a
 version they do not understand.
 
 contents
@@ -282,7 +282,7 @@ extension, defined as follows:
 
 ~~~
    enum {
-       encrypted_client_hello(TBD), (65535)
+       encrypted_client_hello(0xffce), (65535)
    } ExtensionType;
 ~~~
 
@@ -376,7 +376,7 @@ the impact of duplicated extensions, the client may use the
 
 ~~~
    enum {
-       outer_extension(TBD), (65535)
+       outer_extension(0xffcd), (65535)
    } ExtensionType;
 
    struct {
@@ -1106,10 +1106,13 @@ envelope.
 
 ## Update of the TLS ExtensionType Registry
 
-IANA is requested to create an entry, encrypted_client_hello(0xffce),
-in the existing registry for ExtensionType (defined in
-{{!RFC8446}}), with "TLS 1.3" column values being set to
+IANA is requested to create the following two entries in the existing registry
+for ExtensionType (defined in {{!RFC8446}}):
+
+1. encrypted_client_hello(0xffce), with "TLS 1.3" column values being set to
 "CH, EE", and "Recommended" column being set to "Yes".
+2. outer_extension(0xffcd), with the "TLS 1.3" column values being set to
+"CH", and "Recommended" column being set to "Yes".
 
 ## Update of the TLS Alert Registry
 


### PR DESCRIPTION
Once we have some implementations that interop, we'll go ahead with early
codepoint allocation.

The new version matches -07, which will be the next draft version we submit.

cc @martinthomson @grittygrease 

Closes #220.