### PR TITLE
Fix superfluous padding edge cases.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -488,10 +488,11 @@ server's anonymity set without server input. For the "server_name" extension
 with length D, clients SHOULD use the server's length hint L
 (ECHCOnfig.maximum_name_length) when computing the padding as follows:
 
-1. If L > D, add L - D bytes of padding. This rounds to the server's advertised
-   hint, i.e., ECHConfig.maximum_name_length.
-2. Otherwise, add 32 - (D % 32) bytes of padding. This rounds D up to the
-   nearest multiple of 32 bytes.
+1. If L >= D, add L - D bytes of padding. This rounds to the server's
+   advertised hint, i.e., ECHConfig.maximum_name_length.
+2. Otherwise, let P = 31 - ((D - 1) % 32), and add P bytes of padding, plus an
+   additional 32 bytes if D + P < L + 32. This rounds D up to the nearest
+   multiple of 32 bytes.
 
 In addition to padding ClientHelloInner, clients and servers will also need to
 pad all other handshake messages that have sensitive-length fields. For example,

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -492,7 +492,7 @@ with length D, clients SHOULD use the server's length hint L
    advertised hint, i.e., ECHConfig.maximum_name_length.
 2. Otherwise, let P = 31 - ((D - 1) % 32), and add P bytes of padding, plus an
    additional 32 bytes if D + P < L + 32. This rounds D up to the nearest
-   multiple of 32 bytes.
+   multiple of 32 bytes that permits at least 32 bytes of length ambiguity.
 
 In addition to padding ClientHelloInner, clients and servers will also need to
 pad all other handshake messages that have sensitive-length fields. For example,


### PR DESCRIPTION
Consider the following values for L and D, where L is the server's hint
and D is the length of the domain name.

~~~
    D1     D2      D3
... -+--|---+---|---+---|----->
        L     32*n   32*(n+1)
~~~

This change pads D according to the following rules.

- D1: D <= L, so round up to L.
- D2: 32*(n-1) <= L < D <= 32*n, round up to 32*(n+1).
- D3: 32*(n-1) <= L <= 32*n < D, round up to 32*(n+1).

Case D2 exists because the anonymity set of of D, if rounded to 32*n
(instead of 32*(n+1), is less than 32. The new padding algorithm ensures
that the anonymity set for D whenever D > L is at least 32 elements.

Closes #252. Thanks, @bemasc!