### PR TITLE
Proposal: Retry-only ECHConfig

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -479,6 +479,9 @@ particular,
 - encrypted_ch contains the HPKE encapsulated key (enc) and the ClientHelloInner
   ciphertext (encrypted_ch_inner).
 
+If `ECHConfig.public_key` is empty, the client SHOULD instead compute
+`config_digest`, `enc`, and `encrypted_ch` randomly, as in {{grease-extensions}}.
+
 The client MUST place the value of `ECHConfig.public_name` in the
 ClientHelloOuter "server_name" extension. The ClientHelloOuter MUST NOT contain
 a "cached_info" extension {{!RFC7924}} with a CachedObject entry whose


### PR DESCRIPTION
A server operator always has the option to operate in a retry-only mode, which may be necessary if updating the published ECHConfig is difficult and long-lived keys are undesirable.  This change improves forward-secrecy in that configuration.