### PR TITLE
Add ECH confirmation (option (3))

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -187,8 +187,8 @@ following actions:
    to the backend, who terminates the connection. This is referred to as "ECH
    acceptance".
 
-Upon receiving the server's response, the client determines whether ECH was
-accepted or rejected and proceeds with the handshake accordingly. (See
+Upon receiving the server's response, the client determines whether or not ECH
+was accepted and proceeds with the handshake accordingly. (See
 {{client-behavior}} for details.)
 
 # Encrypted ClientHello Configuration {#ech-configuration}
@@ -308,7 +308,7 @@ extension, defined as follows:
 
 The extension request is carried by the ClientHelloOuter, i.e., the ClientHello
 transmitted to the client-facing server. The payload contains the following
-`ClientEncryptedCH` structure:
+`ClientECH` structure:
 
 ~~~~
     struct {
@@ -316,7 +316,7 @@ transmitted to the client-facing server. The payload contains the following
        opaque config_id<0..255>;
        opaque enc<1..2^16-1>;
        opaque encrypted_ch<1..2^16-1>;
-    } ClientEncryptedCH;
+    } ClientECH;
 ~~~~
 
 cipher_suite
@@ -340,14 +340,26 @@ encrypted_ch
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{send-ech}}.
 
-When the client-facing server accepts ECH, it does not send this extension. When
-it rejects, it adds an "encrypted_client_hello" extension to EncryptedExtensions
-with the following structure as the payload:
+When offering the "encrypted_client_hello" extension in its ClientHelloOuter,
+the client MUST also offer an "encrypted_client_hello" extension in its
+ClientHelloInner. The payload of the latter is a value of type `ECHNonce`
+(defined in {{ech-nonce}}) with `nonce` set to a random byte string.
+
+The client-facing server SHOULD include an "encrypted_client_hello" extension in
+its ServerHello in order to confirm ECH usage. (The client interprets the
+absence of this extension as an indication of rejection.) The payload is a value
+of type `ECHNonce`: to indicate rejection, the server sets `nonce` to a random
+byte string; to indicate acceptance, the server sets `nonce` to be the payload
+of the "encrypted_client_hello" extension of the ClientHelloInner.
+
+When the client offers the "encrypted_client_hello" extension, the server MAY
+include an "encrypted_client_hello" extension in its EncryptedExtensions message
+with the following payload:
 
 ~~~
     struct {
        ECHConfigs retry_configs;
-    } ServerEncryptedCH;
+    } ServerECH;
 ~~~
 
 retry_configs
@@ -425,11 +437,11 @@ removes and replaces extensions from ClientHelloInner with a single
 were removed from ClientHelloInner, in the order in which they were removed. The
 hash contains the full ClientHelloInner hash computed above.
 
-This process is reversed by client-facing server. Specifically,
-the server replaces the `outer_extensions` with extensions contained in
-ClientHelloOuter. The server then computes a hash of the reconstructed
-ClientHelloInner. If the hash does not equal OuterExtensions.hash, the server
-aborts the connection with an "illegal_parameter" alert.
+This process is reversed by client-facing server. Specifically, the server
+replaces the `outer_extensions` with extensions contained in ClientHelloOuter.
+The server then computes a hash of the reconstructed ClientHelloInner. If the
+hash does not equal OuterExtensions.hash, the server aborts the connection with
+an "illegal_parameter" alert.
 
 # Client Behavior {#client-behavior}
 
@@ -462,8 +474,10 @@ Note that the HPKE functions Deserialize and SetupBaseS are those which match
 The client then generates a ClientHelloInner value. In addition to the normal
 values, ClientHelloInner MUST also contain:
 
- - an "ech_nonce" extension, containing `ech_nonce_value` derived above
- - TLS padding {{!RFC7685}} (see {{padding}})
+ - an "encrypted_client_hello" extension, as described in
+   {{encrypted-client-hello}};
+ - an "ech_nonce" extension, containing `ech_nonce_value` derived above; and
+ - TLS padding {{!RFC7685}} (see {{padding}}).
 
 When offering an encrypted ClientHello, the client MUST NOT offer to resume any
 non-ECH PSKs. It additionally MUST NOT offer to resume any sessions for TLS 1.2
@@ -524,9 +538,18 @@ to be padded using TLS record layer padding.
 ## Handling the server response {#handle-server-response}
 
 As described in {{server-behavior}}, the server MAY either accept ECH and use
-ClientHelloInner or reject it and use ClientHelloOuter. However, there is no
-indication in ServerHello of which one the server has done and the client must
-therefore use trial decryption in order to determine this.
+ClientHelloInner or reject it and use ClientHelloOuter. In handling the server's
+response, the client's first step is to determine which was used. It proceeds as
+follows.
+
+* If the ServerHello does not contain an "encrypted_client_hello" extension,
+  then the client presumes rejection, since the server may not support ECH.
+* The client checks that the "encrypted_client_hello" extension of the
+  ServerHello contains a well-formed `ECHNonce` as its payload: if not, it MUST
+  abort with an "illegal_parameter" alert.
+* The client checks that the `nonce` field of the payload is equal to the
+  `nonce` it sent in the extension of its ClientHelloInner: if not, then it
+  presumes rejection; otherwise it presumes acceptance.
 
 ### Accepted ECH
 
@@ -542,8 +565,8 @@ the calling application. It MUST NOT use the retry keys.
 
 Otherwise, when the handshake completes successfully with the public name
 authenticated, the client MUST abort the connection with an "ech_required"
-alert. It then processes the "retry_configs" field from the server's
-"encrypted_client_hello" extension.
+alert. It then processes the "retry_configs" field from the
+"encrypted_client_hello" extension sent in the server's EncryptedExtensions.
 
 If one of the values contains a version supported by the client, it can regard
 the ECH keys as securely replaced by the server. It SHOULD retry the handshake
@@ -611,6 +634,8 @@ error code.
 
 ### HelloRetryRequest
 
+[[OPEN ISSUE: How does ECH confirmation logic impact HRR logic?]]
+
 If the server sends a HelloRetryRequest in response to the ClientHello, the
 client sends a second updated ClientHello per the rules in {{RFC8446}}.
 However, at this point, the client does not know whether the server processed
@@ -637,15 +662,15 @@ rationale for this is described in {{flow-hrr-hijack}}.
 
 Client-facing servers perform the corresponding process when decrypting second
 ClientHelloInner messages. In particular, upon receipt of a second ClientHello
-message with a ClientEncryptedCH value, servers setup their HPKE context and
-decrypt ClientEncryptedCH as follows:
+message with a ClientECH value, servers set up their HPKE context and
+decrypt ClientECH as follows:
 
 ~~~
-context = SetupPSKR(ClientEncryptedCH.enc,
+context = SetupPSKR(ClientECH.enc,
   skR, "tls13-ech-hrr", ech_hrr_key, "")
 
 ClientHelloInner =
-  context.Open("", ClientEncryptedCH.encrypted_ch)
+  context.Open("", ClientECH.encrypted_ch)
 
 ech_nonce_value = context.Export("tls13-ech-hrr-nonce", 16)
 ~~~
@@ -690,30 +715,36 @@ Upon receiving an "encrypted_client_hello" extension, the client-facing server
 MUST check that it is able to negotiate TLS 1.3 or greater. If not, it MUST
 abort the connection with a "handshake_failure" alert.
 
-The ClientEncryptedCH value is said to match a known ECHConfig if there exists
+The ClientECH value is said to match a known ECHConfig if there exists
 an ECHConfig that can be used to successfully decrypt
-ClientEncryptedCH.encrypted_ch. This matching procedure should be done using
+ClientECH.encrypted_ch. This matching procedure should be done using
 one of the following two checks:
 
-1. Compare ClientEncryptedCH.config_id against identifiers of known ECHConfig
+1. Compare ClientECH.config_id against identifiers of known ECHConfig
    and choose the one that matches.
-2. Use trial decryption of ClientEncryptedCH.encrypted_ch with known ECHConfig
+2. Use trial decryption of ClientECH.encrypted_ch with known ECHConfig
    and choose the one that succeeds.
 
-Some uses of ECH, such as local discovery mode, may omit the
-ClientEncryptedCH.config_id since it can be used as a tracking vector. In
-such cases, trial decryption should be used for matching ClientEncryptedCH to
-known ECHConfig. Unless specified by the application using (D)TLS or externally
-configured on both sides, implementations MUST use the first method.
+Some uses of ECH, such as local discovery mode, may omit the ClientECH.config_id
+since it can be used as a tracking vector. In such cases, trial decryption
+should be used for matching ClientECH to known ECHConfig. Unless specified by
+the application using (D)TLS or externally configured on both sides,
+implementations MUST use the first method.
 
-If the ClientEncryptedCH value does not match any known ECHConfig structure, it
+If the ClientECH value does not match any known ECHConfig structure, it
 MUST ignore the extension and proceed with the connection, with the following
 added behavior:
 
-- It MUST include the "encrypted_client_hello" extension with the
-  "retry_configs" field set to one or more ECHConfig structures with up-to-date
-  keys. Servers MAY supply multiple ECHConfig values of different versions. This
-  allows a server to support multiple versions at once.
+- It SHOULD include an ECH extension in its ServerHello with a `ECHNonce`
+  payload indicating rejection as specified in {{encrypted-client-hello}}. (The
+  client interprets the absence of this extension as an indication of
+  rejection.)
+
+- It SHOULD include the "encrypted_client_hello" extension in its
+  EncryptedExtensions with the "retry_configs" field set to one or more
+  ECHConfig structures with up-to-date keys. Servers MAY supply multiple
+  ECHConfig values of different versions. This allows a server to support
+  multiple versions at once.
 
 - The server MUST ignore all PSK identities in the ClientHello which correspond
   to ECH PSKs. ECH PSKs offered by the client are associated with the ECH
@@ -721,22 +752,22 @@ added behavior:
   them when using the plaintext SNI name. This restriction allows a client to
   reject resumptions in {{auth-public-name}}.
 
-Note that an unrecognized ClientEncryptedCH.config_id value may be a GREASE
-ECH extension (see {{grease-extensions}}), so it is necessary for servers to
-proceed with the connection and rely on the client to abort if ECH was required.
-In particular, the unrecognized value alone does not indicate a misconfigured
-ECH advertisement ({{misconfiguration}}). Instead, servers can measure
-occurrences of the "ech_required" alert to detect this case.
+Note that an unrecognized ClientECH.config_id value may be a GREASE ECH
+extension (see {{grease-extensions}}), so it is necessary for servers to proceed
+with the connection and rely on the client to abort if ECH was required.  In
+particular, the unrecognized value alone does not indicate a misconfigured ECH
+advertisement ({{misconfiguration}}). Instead, servers can measure occurrences
+of the "ech_required" alert to detect this case.
 
-If the ClientEncryptedCH value matches a known ECHConfig, the server then
-decrypts ClientEncryptedCH.encrypted_ch, using the private key skR corresponding
+If the ClientECH value matches a known ECHConfig, the server then
+decrypts ClientECH.encrypted_ch, using the private key skR corresponding
 to ECHConfig, as follows:
 
 ~~~
-context = SetupBaseR(ClientEncryptedCH.enc, skR, "tls13-ech")
+context = SetupBaseR(ClientECH.enc, skR, "tls13-ech")
 
 ClientHelloInner =
-  context.Open("", ClientEncryptedCH.encrypted_ch)
+  context.Open("", ClientECH.encrypted_ch)
 
 ech_nonce_value = context.Export("tls13-ech-nonce", 16)
 ech_hrr_key = context.Export("tls13-ech-hrr-key", 16)
@@ -834,11 +865,11 @@ then each anonymity set has size k = 1. Client-facing servers SHOULD deploy ECH
 in such a way so as to maximize the size of the anonymity set where possible.
 This means client-facing servers should use the same ECHConfig for as many hosts
 as possible. An attacker can distinguish two hosts that have different ECHConfig
-values based on the ClientEncryptedCH.config_id value. This also means
-public information in a TLS handshake is also consistent across hosts. For
-example, if a client-facing server services many backend origin hosts, only one
-of which supports some cipher suite, it may be possible to identify that host
-based on the contents of unencrypted handshake messages.
+values based on the ClientECH.config_id value. This also means public
+information in a TLS handshake is also consistent across hosts. For example, if
+a client-facing server services many backend origin hosts, only one of which
+supports some cipher suite, it may be possible to identify that host based on
+the contents of unencrypted handshake messages.
 
 ## Unauthenticated and Plaintext DNS {#plaintext-dns}
 
@@ -879,16 +910,16 @@ this problem by flushing any DNS or ECHConfig state upon changing networks.
 Optional configuration identifiers may be useful in scenarios where clients and
 client-facing servers do not want to reveal information about the client-facing
 server in the "encrypted_client_hello" extension. In such settings, clients send
-either an empty config_id or a randomly generated config_id in the
-ClientEncryptedCH. (The precise implementation choice for this mechanism is out
-of scope for this document.) Servers in these settings must perform trial
-decryption since they cannot identify the client's chosen ECH key using the
-config_id value. As a result, support for optional configuration identifiers may
-exacerbate DoS attacks. Specifically, an adversary may send malicious
-ClientHello messages, i.e., those which will not decrypt with any known ECH key,
-in order to force wasteful decryption. Servers that support this feature should,
-for example, implement some form of rate limiting mechanism to limit the damage
-caused by such attacks.
+either an empty config_id or a randomly generated config_id in the ClientECH.
+(The precise implementation choice for this mechanism is out of scope for this
+document.) Servers in these settings must perform trial decryption since they
+cannot identify the client's chosen ECH key using the config_id value. As a
+result, support for optional configuration identifiers may exacerbate DoS
+attacks. Specifically, an adversary may send malicious ClientHello messages,
+i.e., those which will not decrypt with any known ECH key, in order to force
+wasteful decryption. Servers that support this feature should, for example,
+implement some form of rate limiting mechanism to limit the damage caused by
+such attacks.
 
 ## Outer ClientHello
 
@@ -955,7 +986,7 @@ values with different keys using a short TTL.
 ### Prevent SNI-based DoS attacks
 
 This design requires servers to decrypt ClientHello messages with
-ClientEncryptedCH extensions carrying valid digests. Thus, it is possible for an
+ClientECH extensions carrying valid digests. Thus, it is possible for an
 attacker to force decryption operations on the server. This attack is bound by
 the number of valid TCP connections an attacker can open.
 
@@ -1156,7 +1187,7 @@ IANA is requested to create the following two entries in the existing registry
 for ExtensionType (defined in {{!RFC8446}}):
 
 1. encrypted_client_hello(0xff02), with "TLS 1.3" column values being set to
-   "CH, EE", and "Recommended" column being set to "Yes".
+   "CH, SH, EE", and "Recommended" column being set to "Yes".
 2. ech_nonce(0xff03), with the "TLS 1.3" column values being set to "CH", and
    "Recommended" column being set to "Yes".
 3. outer_extension(0xff04), with the "TLS 1.3" column values being set to "CH",


### PR DESCRIPTION
This changes changes the semantics of the "encrypted_client_hello" (aka "ech") extension so that the server confirms ECH acceptance. The client adds an "ech" extension to ClientHelloInner that contains a random nonce; when the server accepts, it echoes this nonce back.

**Protocol flow:**
* **On input of the client's outer CH.** If the server accepts ECH, it uses the inner CH; and if the server rejects or does not support ECH, then it uses the outer CH. If the server accepts, then it adds an "ech" extension to its SH with nonce sent in the "ech" extension of the inner CH; if the server rejects, then it adds an "ech" extension to its SH with a random nonce. It may also add and an "ech" extension to its EE with the updated ECH configuration.
* **On input of the server's SH, EE, …, Finished.** If the SH has the "ech" extension with the payload sent in the inner CH, then it proceeds as if the inner CH was used; otherwise it proceeds as if the outer CH was used, updating its ECH configuration if applicable.

This addresses #274. It also makes the naming of extensions defined in the spec consistent.

REVISED on 9/2.