### PR TITLE
Add ECH confirmation signal

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -959,7 +959,7 @@ in-band when possible, such as through the use of OCSP stapling, and clients
 SHOULD take steps to minimize or protect such requests during certificate
 validation.
 
-## Abuse of ECH Acceptance Signal
+## Attacks Exploiting Acceptance Confirmation
 
 To signal acceptance, the backend server overwrites 8 bytes of its
 ServerHello.random with a value derived from the ClientHelloInner.random. (See


### PR DESCRIPTION
This change provides an explicit confirmation of ECH acceptance. To do so, the backend server overwrites the last 8 bytes of the SH.random with a value derived from ClientHelloInner.random and the first 24 bytes of ServerHello.random.

This addresses #274.

REVISED 9/21.