### PR TITLE
s/Unmarshal/Deserialize/ to align with HPKE

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -446,14 +446,15 @@ the `HpkePublicKey` and KEM identifier corresponding to the server, clients
 compute an HPKE encryption context as follows:
 
 ~~~
-    pkR = HPKE.KEM.Deserialize(ECHConfig.public_key)
+    pkR = Deserialize(ECHConfig.public_key)
     enc, context = SetupBaseS(pkR, "tls13-ech")
     ech_nonce_value = context.Export("tls13-ech-nonce", 16)
     ech_hrr_key = context.Export("tls13-ech-hrr-key", 16)
 ~~~
 
-Note that the HPKE algorithm identifiers are those which match the client's
-chosen preference from `ECHConfig.cipher_suites`.
+Note that the HPKE functions Deserialize and SetupBaseS are those which match
+`ECHConfig.kem_id` and the client's chosen preference from
+`ECHConfig.cipher_suites`.
 
 The client then generates a ClientHelloInner value. In addition to the normal
 values, ClientHelloInner MUST also contain:
@@ -622,7 +623,7 @@ first ClientHelloInner via the derived ech_hrr_key by modifying HPKE setup as
 follows:
 
 ~~~
-pkR = HPKE.KEM.Deserialize(ECHConfig.public_key)
+pkR = Deserialize(ECHConfig.public_key)
 enc, context = SetupPSKS(pkR, "tls13-ech-hrr", ech_hrr_key, "")
 ech_nonce_value = context.Export("tls13-ech-hrr-nonce", 16)
 ~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -446,7 +446,7 @@ the `HpkePublicKey` and KEM identifier corresponding to the server, clients
 compute an HPKE encryption context as follows:
 
 ~~~
-    pkR = HPKE.KEM.Unmarshal(ECHConfig.public_key)
+    pkR = HPKE.KEM.Deserialize(ECHConfig.public_key)
     enc, context = SetupBaseS(pkR, "tls13-ech")
     ech_nonce_value = context.Export("tls13-ech-nonce", 16)
     ech_hrr_key = context.Export("tls13-ech-hrr-key", 16)
@@ -622,7 +622,7 @@ first ClientHelloInner via the derived ech_hrr_key by modifying HPKE setup as
 follows:
 
 ~~~
-pkR = HPKE.KEM.Unmarshal(ECHConfig.public_key)
+pkR = HPKE.KEM.Deserialize(ECHConfig.public_key)
 enc, context = SetupPSKS(pkR, "tls13-ech-hrr", ech_hrr_key, "")
 ech_nonce_value = context.Export("tls13-ech-hrr-nonce", 16)
 ~~~


### PR DESCRIPTION
draft-irtf-cfrg-hpke-05 switched from Unmarshal to Deserialize. Switch
ECH to match. See #294.