### PR TITLE
Require HRR-sensitive parameters match in ClientHello(Outer|Inner).

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -656,14 +656,14 @@ error code.
 ### Handling HelloRetryRequest {#client-hrr}
 
 As required in {{send-ech}}, clients offering ECH MUST ensure that
-HelloRetryRequest-sensitive parameters applicable to TLS 1.3 and higher
+HelloRetryRequest-sensitive parameters applicable to TLS 1.3 or higher
 versions in ClientHelloInner match that in ClientHelloOuter. These parameters
 include:
 
 1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list; and
-1. The "key_share" and "supported_groups" extensions {{RFC8446}}. (These
-extensions may be copied from ClientHelloOuter into ClientHelloInner as
-described in {{send-ech}}.)
+1. The "key_share", "supported_groups", and "supported_versions" extensions
+{{RFC8446}}. (These extensions may be copied from ClientHelloOuter into
+ClientHelloInner as described in {{send-ech}}.)
 
 Future extensions that influence the conditions in which servers send a
 HelloRetryRequest MUST also match across ClientHelloOuter and ClientHelloInner.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -478,9 +478,9 @@ it does a standard ClientHello, with the exception of the following rules:
 1. It MUST offer to negotiate TLS 1.3 or above.
 1. If it compressed any extensions in EncodedClientHelloInner, it MUST copy the
    corresponding extensions from ClientHelloInner.
-1. It MUST ensure that all HelloRetryRequest-sensitive parameters applicable
-   to TLS 1.3 and higher versions in ClientHelloInner match that in
-   ClientHelloOuter. See {{hrr}} for the list of these parameters.   
+1. It MUST ensure that all extensions or parameters in ClientHelloInner that
+   might change in response to receiving HelloRetryRequest match that in
+   ClientHelloOuter. See {{client-hrr}} for the list of these parameters.
 1. It MAY copy any other field from the ClientHelloInner except
    ClientHelloInner.random. Instead, It MUST generate a fresh
    ClientHelloOuter.random using a secure random number generator. (See
@@ -655,10 +655,10 @@ error code.
 
 ### Handling HelloRetryRequest {#client-hrr}
 
-As required in {{send-ech}}, clients offering ECH MUST ensure that
-HelloRetryRequest-sensitive parameters applicable to TLS 1.3 or higher
-versions in ClientHelloInner match that in ClientHelloOuter. These parameters
-include:
+As required in {{send-ech}}, clients offering ECH MUST ensure that all
+extensions or parameters in ClientHelloInner applicable to TLS 1.3 or higher
+versions that might change in response to receiving HelloRetryRequest match
+that in ClientHelloOuter. These parameters include:
 
 1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list.
 1. The "key_share" and "supported_groups" extensions {{RFC8446}}. (These
@@ -668,8 +668,8 @@ described in {{send-ech}}.)
 earlier. Note the ClientHelloOuter MAY include these older versions, while the
 ClientHelloInner MUST omit them.
 
-Future extensions that influence the conditions in which servers send a
-HelloRetryRequest MUST also match across ClientHelloOuter and ClientHelloInner.
+Future extensions that might change across first and second ClientHello messages
+in response to a HelloRetryRequest MUST match.
 
 If the server sends a HelloRetryRequest in response to the ClientHello, the
 client sends a second updated ClientHello per the rules in {{RFC8446}}.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -478,6 +478,14 @@ it does a standard ClientHello, with the exception of the following rules:
 1. It MUST offer to negotiate TLS 1.3 or above.
 1. If it compressed any extensions in EncodedClientHelloInner, it MUST copy the
    corresponding extensions from ClientHelloInner.
+1. It MUST ensure that all HelloRetryRequest-sensitive parameters applicable
+   to TLS 1.3 and higher versions in ClientHelloInner match that in
+   ClientHelloOuter. This includes ciphersuites for TLS 1.3 in
+   ClientHello.cipher_suites list, as well as the "key_shares" and
+   "supported_groups" extensions. (These extensions may be copied from the
+   ClientHelloOuter as described below.) Future extensions that influence the
+   conditions in which servers send HelloRetryRequest MUST also match across
+   ClientHelloOuter and ClientHelloInner.
 1. It MAY copy any other field from the ClientHelloInner except
    ClientHelloInner.random. Instead, It MUST generate a fresh
    ClientHelloOuter.random using a secure random number generator. (See

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -480,7 +480,7 @@ it does a standard ClientHello, with the exception of the following rules:
    corresponding extensions from ClientHelloInner.
 1. It MUST ensure that all extensions or parameters in ClientHelloInner that
    might change in response to receiving HelloRetryRequest match that in
-   ClientHelloOuter. See {{client-hrr}} for the list of these parameters.
+   ClientHelloOuter. See {{client-hrr}} for more information.
 1. It MAY copy any other field from the ClientHelloInner except
    ClientHelloInner.random. Instead, It MUST generate a fresh
    ClientHelloOuter.random using a secure random number generator. (See
@@ -494,6 +494,15 @@ it does a standard ClientHello, with the exception of the following rules:
    extension.
 1. It MUST NOT include the "pre_shared_key" extension. (See
    {{flow-clienthello-malleability}}.)
+
+[[OPEN ISSUE: We currently require HRR-sensitive parameters to match in
+ClientHelloInner and ClientHelloOuter in order to simplify client-side
+logic in the event of HRR. See
+https://github.com/tlswg/draft-ietf-tls-esni/pull/316
+for more information. We might also solve this by including an explicit
+signal in HRR noting ECH acceptance. We need to decide if inner/outer
+variance is important for HRR-sensitive parameters, and if so, how to
+best deal with it without complicated client logic.]]
 
 The client might duplicate non-sensitive extensions in both messages. However,
 implementations need to take care to ensure that sensitive extensions are not
@@ -655,15 +664,17 @@ error code.
 
 ### Handling HelloRetryRequest {#client-hrr}
 
-As required in {{send-ech}}, clients offering ECH MUST ensure that all
-extensions or parameters in ClientHelloInner applicable to TLS 1.3 or higher
-versions that might change in response to receiving HelloRetryRequest match
-that in ClientHelloOuter. These parameters include:
+As required in {{real-ech}}, clients offering ECH MUST ensure that all
+extensions or parameters that might change in response to receiving a
+HelloRetryRequest have the same values in ClientHelloInner and
+ClientHelloOuter. That is, if a HelloRetryRequest causes a parameter to be
+changed, the same change is applied to both ClientHelloInner and
+ClientHelloOuter. Applicable parameters include:
 
 1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list.
 1. The "key_share" and "supported_groups" extensions {{RFC8446}}. (These
 extensions may be copied from ClientHelloOuter into ClientHelloInner as
-described in {{send-ech}}.)
+described in {{real-ech}}.)
 1. Versions in the "supported_versions" extension, excluding TLS 1.2 and
 earlier. Note the ClientHelloOuter MAY include these older versions, while the
 ClientHelloInner MUST omit them.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -660,10 +660,13 @@ HelloRetryRequest-sensitive parameters applicable to TLS 1.3 or higher
 versions in ClientHelloInner match that in ClientHelloOuter. These parameters
 include:
 
-1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list; and
-1. The "key_share", "supported_groups", and "supported_versions" extensions
-{{RFC8446}}. (These extensions may be copied from ClientHelloOuter into
-ClientHelloInner as described in {{send-ech}}.)
+1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list.
+1. The "key_share" and "supported_groups" extensions {{RFC8446}}. (These
+extensions may be copied from ClientHelloOuter into ClientHelloInner as
+described in {{send-ech}}.)
+1. Versions in the "supported_versions" extension, excluding TLS 1.2 and
+earlier. Note the ClientHelloOuter MAY include these older versions, while the
+ClientHelloInner MUST omit them.
 
 Future extensions that influence the conditions in which servers send a
 HelloRetryRequest MUST also match across ClientHelloOuter and ClientHelloInner.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -480,12 +480,7 @@ it does a standard ClientHello, with the exception of the following rules:
    corresponding extensions from ClientHelloInner.
 1. It MUST ensure that all HelloRetryRequest-sensitive parameters applicable
    to TLS 1.3 and higher versions in ClientHelloInner match that in
-   ClientHelloOuter. This includes ciphersuites for TLS 1.3 in
-   ClientHello.cipher_suites list, as well as the "key_shares" and
-   "supported_groups" extensions. (These extensions may be copied from the
-   ClientHelloOuter as described below.) Future extensions that influence the
-   conditions in which servers send HelloRetryRequest MUST also match across
-   ClientHelloOuter and ClientHelloInner.
+   ClientHelloOuter. See {{hrr}} for the list of these parameters.   
 1. It MAY copy any other field from the ClientHelloInner except
    ClientHelloInner.random. Instead, It MUST generate a fresh
    ClientHelloOuter.random using a secure random number generator. (See
@@ -659,6 +654,19 @@ implemented, for instance, by reporting a failed connection with a dedicated
 error code.
 
 ### Handling HelloRetryRequest {#client-hrr}
+
+As required in {{send-ech}}, clients offering ECH MUST ensure that
+HelloRetryRequest-sensitive parameters applicable to TLS 1.3 and higher
+versions in ClientHelloInner match that in ClientHelloOuter. These parameters
+include:
+
+1. TLS 1.3 {{!RFC8446}} ciphersuites in the ClientHello.cipher_suites list; and
+1. The "key_share" and "supported_groups" extensions {{RFC8446}}. (These
+extensions may be copied from ClientHelloOuter into ClientHelloInner as
+described in {{send-ech}}.)
+
+Future extensions that influence the conditions in which servers send a
+HelloRetryRequest MUST also match across ClientHelloOuter and ClientHelloInner.
 
 If the server sends a HelloRetryRequest in response to the ClientHello, the
 client sends a second updated ClientHello per the rules in {{RFC8446}}.


### PR DESCRIPTION
Closes #233.

This is limited to parameters applicable to TLS 1.3 and beyond. For example,
TLS 1.2 ciphersuites may appear in ClientHelloOuter, so long as all TLS 1.3
ciphersuites in ClientHelloOuter match that in ClientHelloInner.

cc @davidben, @cjpatton