### PR TITLE
Clarify client handling of retry keys with GREASE.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -688,7 +688,8 @@ structure available for the server, it SHOULD send a GREASE {{?RFC8701}}
 
 If the server sends an "encrypted_client_hello" extension, the client MUST check
 the extension syntactically and abort the connection with a "decode_error" alert
-if it is invalid.
+if it is invalid. It otherwise ignores the extension and MUST NOT use the retry
+keys.
 
 Offering a GREASE extension is not considered offering an encrypted ClientHello
 for purposes of requirements in {{client-behavior}}. In particular, the client


### PR DESCRIPTION
The intent was that the server always sends the retry keys (it cannot
distinguish stale keys from GREASE when the client is actually trying to
connect to the public name), while the client just ignores them, but I
did a poor job of describing this, so add a key sentence.

This addresses #295.