### PR TITLE
Replace inner_digest with ClientHelloOuterAAD

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -397,7 +397,7 @@ reference an extension in ClientHelloOuter.
 When sending ClientHello, the client first computes ClientHelloInner, including
 any PSK binders. It then computes a new value, the EncodedClientHelloInner, by
 first making a copy of ClientHelloInner. It then replaces the legacy\_session\_id
-field with an empty value.
+field with an empty string.
 
 The client then MAY substitute extensions which it knows will be duplicated in
 ClientHelloOuter. To do so, the client removes and replaces extensions from
@@ -426,10 +426,10 @@ ClientHelloInner.
 
 To prevent a network attacker from modifying the reconstructed ClientHelloInner
 (see {{flow-clienthello-malleability}}), ECH authenticates ClientHelloOuter by
-deriving a ClientHelloOuterAAD value. This is computed by serializing ClientHelloOuter
-with the "encrypted_client_hello" extension removed.
-ClientHelloOuterAAD is then passed as the associated data parameter to the
-HPKE encryption.
+deriving a ClientHelloOuterAAD value. This is computed by serializing
+ClientHelloOuter with the "encrypted_client_hello" extension removed.
+ClientHelloOuterAAD is then passed as the associated data parameter to the HPKE
+encryption.
 
 Note the decompression process in {{encoding-inner}} forbids
 "encrypted_client_hello" in OuterExtensions. This ensures the unauthenticated

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -426,8 +426,8 @@ ClientHelloInner.
 
 To prevent a network attacker from modifying the reconstructed ClientHelloInner
 (see {{flow-clienthello-malleability}}), ECH authenticates ClientHelloOuter by
-deriving a ClientHelloOuterAAD value. This is computed by removing the
-"encrypted_client_hello" extension from ClientHelloOuter and serializing it.
+deriving a ClientHelloOuterAAD value. This is computed by serializing ClientHelloOuter
+with the "encrypted_client_hello" extension removed.
 ClientHelloOuterAAD is then passed as the associated data parameter to the
 HPKE encryption.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -396,7 +396,7 @@ reference an extension in ClientHelloOuter.
 
 When sending ClientHello, the client first computes ClientHelloInner, including
 any PSK binders. It then computes a new value, the EncodedClientHelloInner, by
-first making a copy of ClientHelloInner. It then replaces the legacy_session_id
+first making a copy of ClientHelloInner. It then replaces the legacy\_session\_id
 field with an empty value.
 
 The client then MAY substitute extensions which it knows will be duplicated in

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -487,7 +487,7 @@ To encrypt EncodedClientHelloInner, the client first computes
 ClientHelloOuterAAD as described in {{authenticating-outer}}. Note this
 requires the "encrypted_client_hello" be computed after all other extensions.
 In particular, this is possible because the "pre_shared_key" extension is
-forbidden.
+forbidden in ClientHelloOuter.
 
 The client then generates the HPKE encryption context. Finally, it computes the
 encapsulated key, context, HRR key (see {{client-hrr}}), and payload as:


### PR DESCRIPTION
Closes #323. The first commit shaves 33 bytes (or 49 with SHA-384) from the ciphertext by replacing inner_digest with ClientHelloOuterAAD. This also allows for more compact ClientHelloInner encodings when non-extension fields are expected to match. The second commit shaves a further 32 bytes.

We could probably further optimize the encoding but I've left it alone here. In particular, if we merge #316, all non-extension fields may as well be implicit. We could then replace the encryption payload with a plain extensions block.