### PR TITLE
Trial decryption and ECHConfig binding fixes

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -782,15 +782,11 @@ unmodified.
 
 Otherwise, if all candidate ECHConfigs fail to decrypt the extension, the
 client-facing server MUST ignore the extension and proceed with the connection
-using ClientHelloOuter, with the following added behavior:
-
-- It MUST include the "encrypted_client_hello" extension in its
-  EncryptedExtensions with the "retry_configs" field set to one or more
-  ECHConfig structures with up-to-date keys. Servers MAY supply multiple
-  ECHConfig values of different versions. This allows a server to support
-  multiple versions at once.
-- If offered, the server MUST ignore the "pre_shared_key" extension in the
-  ClientHello.
+using ClientHelloOuter. This connection proceeds as usual, except the server
+MUST include the "encrypted_client_hello" extension in its EncryptedExtensions
+with the "retry_configs" field set to one or more ECHConfig structures with
+up-to-date keys. Servers MAY supply multiple ECHConfig values of different
+versions. This allows a server to support multiple versions at once.
 
 Note that decryption failure could indicate a GREASE ECH extension (see
 {{grease-extensions}}), so it is necessary for servers to proceed with the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -722,7 +722,7 @@ MAY offer to resume sessions established without ECH.
 
 # Server Behavior {#server-behavior}
 
-## Client-Facing Server
+## Client-Facing Server {#client-facing-server}
 
 Upon receiving an "encrypted_client_hello" extension, the client-facing server
 determines if it will accept ECH, prior to negotiating any other TLS parameters.
@@ -806,9 +806,12 @@ transmitted on the wire by the client:
 1. If CH1 contains the "encrypted_client_hello" extension but CH2 does not, or
    if CH2 contains the "encrypted_client_hello" extension but CH1 does not, then
    the server MUST abort the handshake with an "illegal_parameter" alert.
-1. Suppose the "encrypted_client_hello" extension is sent in both CH1 and CH2,
-   If the configuration identifier (see {{ech-configuration}}) differs between
-   CH1 and CH2, then the server MUST abort with an "illegal_parameter" alert.
+1. If the "encrypted_client_hello" extension is sent in both CH1 and CH2,
+   the server follows the procedure in {{client-facing-server}} to decrypt the
+   second ClientHelloOuter, but it uses the previously-selected ECHConfig as
+   the set of candidate ECHConfigs. If decryption fails, the server aborts the
+   connection with a "decrypt_error" alert rather than continuing the handshake
+   with the second ClientHelloOuter.
 
 [[OPEN ISSUE: If the client-facing server implements stateless HRR, it has no
 way to send a cookie, short of as-yet-unspecified integration with the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -492,7 +492,8 @@ encapsulated key, context, HRR key (see {{client-hrr}}), and payload as:
 
 ~~~
     pkR = Deserialize(ECHConfig.public_key)
-    enc, context = SetupBaseS(pkR, "tls ech" || 0x00 || ECHConfig)
+    enc, context = SetupBaseS(pkR,
+                              "tls ech" || 0x00 || ECHConfig)
     ech_hrr_key = context.Export("tls ech hrr key", 32)
     payload = context.Seal(ClientHelloOuterAAD,
                            EncodedClientHelloInner)
@@ -807,12 +808,11 @@ transmitted on the wire by the client:
 1. If CH1 contains the "encrypted_client_hello" extension but CH2 does not, or
    if CH2 contains the "encrypted_client_hello" extension but CH1 does not, then
    the server MUST abort the handshake with an "illegal_parameter" alert.
-1. If the "encrypted_client_hello" extension is sent in both CH1 and CH2,
-   the server follows the procedure in {{client-facing-server}} to decrypt the
-   second ClientHelloOuter, but it uses the previously-selected ECHConfig as
-   the set of candidate ECHConfigs. If decryption fails, the server aborts the
-   connection with a "decrypt_error" alert rather than continuing the handshake
-   with the second ClientHelloOuter.
+1. If the "encrypted_client_hello" extension is sent in CH2, the server follows
+   the procedure in {{client-facing-server}} to decrypt the extension, but it
+   uses the previously-selected ECHConfig as the set of candidate ECHConfigs.
+   If decryption fails, the server aborts the connection with a "decrypt_error"
+   alert rather than continuing the handshake with the second ClientHelloOuter.
 
 [[OPEN ISSUE: If the client-facing server implements stateless HRR, it has no
 way to send a cookie, short of as-yet-unspecified integration with the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -515,7 +515,8 @@ a `ClientECH` with the following values:
 If optional configuration identifiers (see {{optional-configs}})) are used, the
 `config_id` field MAY be empty or randomly generated. Unless specified by the
 application using (D)TLS or externally configured on both sides,
-implementations MUST NOT use this mode.
+implementations MUST compute the field as specified in
+{{encrypted-client-hello}}.
 
 ## Recommended Padding Scheme {#padding}
 
@@ -731,7 +732,7 @@ ClientHello to process, so even the client's TLS version preferences may have
 changed.
 
 First, the server collects a set of candidate ECHConfigs. This set is
-determined in one of the two following methods:
+determined by one of the two following methods:
 
 1. Compare ClientECH.config_id against identifiers of known ECHConfigs and
    select the one that matches, if any, as a candidate.


### PR DESCRIPTION
The spec describes an optional trial decryption mode, but most of the text contradicts it. This PR fixes the text up and tries to unify their processing models. In doing so, it flips the error handling from decrypt_error to fallback to be consistent. This, combined with the ClientHelloOuterAAD change, plugs an active sticking out attack for free. It also makes #342 easier because GREASE config_id collisions with real config_ids are now harmless.

Along the way, @chris-wood and @cjpatton observed that we're not authenticating the ECHConfig at all. (It used to be authenticated by way of the config_id, which was a digest.) Instead, just pass the ECHConfig into the info field of the HPKE context. They also noticed the server rule about PSKs on ClientHelloOuter didn't work with GREASE. Instead, we can simply remove it.