### PR TITLE
Use the same HPKE context between the two ClientHellos

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -803,9 +803,10 @@ unrecognized value alone does not indicate a misconfigured ECH advertisement
 
 ### Handling HelloRetryRequest {#server-hrr}
 
-After sending or forwarding a HelloRetryRequest, the client-facing server does not repeat the
-steps in {{client-facing-server}} with the second ClientHelloOuter. Instead it
-continues with the ECHConfig selection from the first ClientHelloOuter as follows:
+After sending or forwarding a HelloRetryRequest, the client-facing server does
+not repeat the steps in {{client-facing-server}} with the second
+ClientHelloOuter. Instead it continues with the ECHConfig selection from the
+first ClientHelloOuter as follows:
 
 If the client-facing server accepted ECH, it checks the second ClientHelloOuter
 also contains the "encrypted_client_hello" extension. If not, it MUST abort the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -803,9 +803,9 @@ unrecognized value alone does not indicate a misconfigured ECH advertisement
 
 ### Handling HelloRetryRequest {#server-hrr}
 
-After sending a HelloRetryRequest, the client-facing server does not repeat the
+After sending or forwarding a HelloRetryRequest, the client-facing server does not repeat the
 steps in {{client-facing-server}} with the second ClientHelloOuter. Instead it
-continues the selections from the first ClientHelloOuter as follows:
+continues with the ECHConfig selection from the first ClientHelloOuter as follows:
 
 If the client-facing server accepted ECH, it checks the second ClientHelloOuter
 also contains the "encrypted_client_hello" extension. If not, it MUST abort the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -830,8 +830,8 @@ backend server unmodified.
 
 If the client-facing server rejected ECH, or if the first ClientHello did not
 include an "encrypted_client_hello" extension, the client-facing server
-proceeds with the connection as usual, without decrypting any new
-ClientECH.payload value.
+proceeds with the connection as usual. The server does not decrypt the
+second ClientHello's ClientECH.payload value, if there is one.
 
 [[OPEN ISSUE: If the client-facing server implements stateless HRR, it has no
 way to send a cookie, short of as-yet-unspecified integration with the


### PR DESCRIPTION
(Note: this PR sits on top of #351, though hopefully the combined diff is also readable enough.)

Closes #349. This achieves the same security properties of ech_hrr_key, but gives us a few improvements:

- Client-facing servers that offload their HPKE operations to RPCs do not need to worry about race conditions with rotation between the two ClientHellos. (See #325.)

- We only perform one addition asymmetric operation with ECH, rather than sometimes two. For servers with offloaded ECH keys, this also avoids an extra RPC call.

- HPKE implementations for ECH only need SetupBase* and not SetupPSK*.

- The description of HRR handling in general can be greatly simplified. Rather than running the server's CH1 algorithm with various modifications, we can just write a straightforward, simpler algorithm.

This PR also adds some missing text for GREASE on HRR, which closes #356. (Although it's worth noting that HRR connections can be easily distinguished by an active attacker anyway. This PR doesn't change this, but makes it much clearer.)