### PR TITLE
Derive accept confirmation from the handshake secret 

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -845,9 +845,10 @@ Upon receipt of an empty "encrypted_client_hello" extension, if the backend
 server negotiates TLS 1.3 or higher, then it MUST confirm ECH acceptance to the
 client by computing its ServerHello as described here.
 
-The backend server begins by generating a message ServerHelloECHConf, which is identical
-in content to a ServerHello message with the exception that ServerHelloECHConf.random is
-equal to 24 random bytes followed by 8 zero bytes. It then computes a string
+The backend server begins by generating a message ServerHelloECHConf, which is
+identical in content to a ServerHello message with the exception that
+ServerHelloECHConf.random is equal to 24 random bytes followed by 8 zero bytes.
+It then computes a string
 
 ~~~
     accept_confirmation =


### PR DESCRIPTION
[Originally suggested by Karthik Bhargavan](https://mailarchive.ietf.org/arch/msg/tls/XsWf4f7-apwOlehe4j0_qKB3zV4/), this change mitigates an active "don't stick out" attack [pointed out by Christian Huitema](https://mailarchive.ietf.org/arch/msg/tls/EAeKCNq7JAFm8DFaoe2MwSslZTQ/). The attack is as follows.

```
Client                       Attacker             Server
CH
 +encrypted_client_hello
 +key_share (g^x)        --> CH -->               SH
                                                   +key_share (g^y)
                             SH'              <-- EE
                              +key_share (g^a)
                         <-- EE'
```

1. The attacker intercepts the client's first flow (`CH`) and forwards it to the
   server.
2. The attacker intercepts the server's first flow and transforms `SH` and `EE` into
   `SH'` and `EE'` respectively, as follows. `SH'` is just like `SH` except that the
   key share `g^y` is replaced with key share `g^a`, where `a` is known to the
   attacker. `EE'` is a malformed handshake message encrypted using a key derived
   from `g^xa`. Finally, it sends `SH'..EE'` to the client.
3. If the client aborts with a "bad_record_mac" alert, then the attacker guesses
   that real-ECH was used. Otherwise, it guesses that grease-ECH was used.