### PR TITLE
Add is_client_hello_inner extension.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -761,7 +761,7 @@ MAY offer to resume sessions established without ECH.
 
 # Server Behavior {#server-behavior}
 
-Servers that that support ECH play one of two roles, depending on the extension
+Servers that support ECH play one of two roles, depending on the extension
 in the ClientHello. If the "encrypted_client_hello" extension is present, the
 server acts as a client-facing server and proceeds as described in
 {{client-facing-server}} to extract a ClientHelloInner, if available. If the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -891,7 +891,9 @@ See issue #333.]]
 
 Upon receipt of an "ech_is_inner" extension in a ClientHello, if the backend
 server negotiates TLS 1.3 or higher, then it MUST confirm ECH acceptance to the
-client by computing its ServerHello as described here.
+client by computing its ServerHello as described here. If both the "ech_is_inner" 
+extension and "encrypted_client_hello" extensions are present in the ClientHello, 
+the backend server MUST abort with an "illegal_parameter" alert.
 
 The backend server begins by generating a message ServerHelloECHConf, which is
 identical in content to a ServerHello message with the exception that

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -532,7 +532,7 @@ application using (D)TLS or externally configured on both sides,
 implementations MUST compute the field as specified in
 {{encrypted-client-hello}}.
 
-### Extension that Indicates ClientHelloInner {#is-inner}
+### ClientHelloInner Indication Extension {#is-inner}
 
 If, in a ClientHello, the "encrypted_client_hello" extension is not present and
 an "ech_is_inner" extension is present, the ClientHello is a
@@ -755,9 +755,9 @@ parameters. Note that successfully decrypting the extension will result in a new
 ClientHello to process, so even the client's TLS version preferences may have
 changed.
 
-(If the client offers the "ech_is_inner" extension ({{is-inner}})
+If the client offers the "ech_is_inner" extension ({{is-inner}})
 in addition to the "encrypted_client_hello" extension, the server MUST abort
-with an "illegal_parameter" alert.)
+with an "illegal_parameter" alert.
 
 First, the server collects a set of candidate ECHConfigs. This set is
 determined by one of the two following methods:

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -892,7 +892,7 @@ See issue #333.]]
 Upon receipt of an "ech_is_inner" extension in a ClientHello, if the backend
 server negotiates TLS 1.3 or higher, then it MUST confirm ECH acceptance to the
 client by computing its ServerHello as described here. If both the "ech_is_inner" 
-and "encrypted_client_hello" extensions are present in the ClientHello, the backend 
+and "encrypted_client_hello" extensions are present in the ClientHello, the backend
 server MUST abort with an "illegal_parameter" alert.
 
 The backend server begins by generating a message ServerHelloECHConf, which is

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -892,8 +892,8 @@ See issue #333.]]
 Upon receipt of an "ech_is_inner" extension in a ClientHello, if the backend
 server negotiates TLS 1.3 or higher, then it MUST confirm ECH acceptance to the
 client by computing its ServerHello as described here. If both the "ech_is_inner" 
-extension and "encrypted_client_hello" extensions are present in the ClientHello, 
-the backend server MUST abort with an "illegal_parameter" alert.
+and "encrypted_client_hello" extensions are present in the ClientHello, the backend 
+server MUST abort with an "illegal_parameter" alert.
 
 The backend server begins by generating a message ServerHelloECHConf, which is
 identical in content to a ServerHello message with the exception that

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -889,7 +889,7 @@ See issue #333.]]
 
 ## Backend Server {#backend-server}
 
-Upon receipt of an "ech_is_inner" extension, if the backend
+Upon receipt of an "ech_is_inner" extension in a ClientHello, if the backend
 server negotiates TLS 1.3 or higher, then it MUST confirm ECH acceptance to the
 client by computing its ServerHello as described here.
 


### PR DESCRIPTION
Resolves a second issue detailed in https://github.com/tlswg/draft-ietf-tls-esni/issues/348. Replaces the empty encrypted_client_hello extension with a new extension, is_client_hello_inner, to indicate that the ClientHello is a ClientHelloInner.

Let me know if I've completely misunderstood what the issue was or what the fix was supposed to be.