### PR TITLE
Remove backticks from empty string literal.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -342,7 +342,7 @@ config_id
 `Expand(Extract("", config), "tls ech config id", 8)`, unless it is optional
 for an application; see {{optional-configs}}. `config` is the `ECHConfig`
 structure. `Extract` and `Expand` are as specified by the cipher suite KDF.
-(Passing the literal `""` as the salt is interpreted by `Extract` as no salt
+(Passing the literal "" as the salt is interpreted by `Extract` as no salt
 being provided.)
 
 enc


### PR DESCRIPTION
The backtick-quoted empty string translates to """" in the text output.