### PR TITLE
Fix ClientHelloOuterAAD.outer_hello length

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -427,10 +427,10 @@ the following structure:
 
 ~~~
     struct {
-       ECHCipherSuite cipher_suite; // ClientECH.cipher_suite
-       opaque config_id<0..255>;    // ClientECH.config_id
-       opaque enc<1..2^16-1>;       // ClientECH.enc
-       opaque outer_hello<1..2^16>;
+       ECHCipherSuite cipher_suite;   // ClientECH.cipher_suite
+       opaque config_id<0..255>;      // ClientECH.config_id
+       opaque enc<1..2^16-1>;         // ClientECH.enc
+       opaque outer_hello<1..2^24-1>;
     } ClientHelloOuterAAD;
 ~~~
 


### PR DESCRIPTION
Per RFC8446, Section 4, handshake messages, including ClientHello, may
be up to 2^24-1 bytes in length.