### PR TITLE
Clarify ClientHelloOuterAAD serialization

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -438,7 +438,8 @@ The first three parameters are equal to, respectively, the
 `ClientECH.cipher_suite`, `ClientECH.config_id`, and `ClientECH.enc` fields of
 the payload of the "encrypted_client_hello" extension. The last parameter,
 `outer_hello`, is computed by serializing ClientHelloOuter with the
-"encrypted_client_hello" extension removed.
+"encrypted_client_hello" extension removed. Note this does not include the
+four-byte header included in the Handshake structure.
 
 Note the decompression process in {{encoding-inner}} forbids
 "encrypted_client_hello" in OuterExtensions. This ensures the unauthenticated


### PR DESCRIPTION
Clarifies that serialization of this structure doesn't include the message type and length. We do the same thing for the serialization of EncodedClientHelloInner, but this makes it explicit in case it's not clear from context.