### PR TITLE
Mirror early_data in ClientHelloOuter when applicable.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -533,6 +533,10 @@ it does a standard ClientHello, with the exception of the following rules:
    "server_name" extension.
 1. It MUST NOT include the "pre_shared_key" extension. (See
    {{flow-clienthello-malleability}}.)
+1. When the client offers the "early_data" extension in ClientHelloInner, it
+   MUST also include the "early_data" extension in ClientHelloOuter. This
+   allows servers that reject ECH and use ClientHelloOuter to safely ignore any
+   early data sent by the client per {{RFC8446}}, Section 4.2.10.
 
 [[OPEN ISSUE: We currently require HRR-sensitive parameters to match in
 ClientHelloInner and ClientHelloOuter in order to simplify client-side

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -533,7 +533,7 @@ it does a standard ClientHello, with the exception of the following rules:
 1. The value of `ECHConfig.contents.public_name` MUST be placed in the
    "server_name" extension.
 1. When the client offers the "pre_shared_key" extension in ClientHelloInner, it
-   MUST also include a GREASE "pre_shared_key" extension in ClientHelloOuter,
+   SHOULD also include a GREASE "pre_shared_key" extension in ClientHelloOuter,
    generated in the manner described in {{grease-psk}}. The client MUST NOT use
    this extension to advertise a PSK to the client-facing server. (See
    {{flow-clienthello-malleability}}.) When the client includes a GREASE


### PR DESCRIPTION
This should probably land after #414.

Closes #408.

cc @davidben