### PR TITLE
Relax public_name to public_identity and describe how clients construct CHOuter based on it.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -275,7 +275,7 @@ or if names can be added or removed from the anonymity set during the lifetime
 of a particular ECH configuration.
 
 public_identity
-: The identity of the client-facing server, i.e., the entity trusted to updat
+: The identity of the client-facing server, i.e., the entity trusted to update
 the ECH configuration. This is used to construct the ClientHelloOuter, as
 described in {{handle-server-response}}. This MUST be a valid DNS name or
 IP address as described in {{identity-validate}}. Clients MUST ignore any


### PR DESCRIPTION
(This change assumes the answers to (1) and (2) from #424 are both "yes.")

Previously, public_name was assumed to be a DNS name. #413 added validation criteria for this value. This change relaxes public_name to be a reference identity for the client-facing server. As a result, clients use this identity when constructing CHOuter and authenticating the client-facing server. This identity may be either a DNS name or an IP address, depending on the particular client-facing server deployment.

I'm totally open to bike shedding the validation criteria, but would really like to hear high-level opinions on this change before doing so.

cc @bemasc, @davidben, @sftcd, @martinthomson, @dmcardle 

Closes #424, #405, #396