### PR TITLE
Add some security considerations for cookie values.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1254,6 +1254,30 @@ connection to that same host after ECH deployment. An adversary that observes
 this can deduce that the ECH-enabled connection was made to a host that the
 client previously connected to and which is within the same anonymity set.
 
+## Cookies
+
+Section 4.2.2 of {{RFC8446}} defines a cookie value that servers may send in
+HelloRetryRequest for clients to echo in the second ClientHello. These values
+are sent unencrypted in ECH. This means differences in cookies between backend
+servers, such as lengths or cleartext components, may leak information about
+the server identity.
+
+Backend servers in an anonymity set SHOULD NOT reveal information in the cookie
+which identifies the server. This may be done by handling HelloRetryRequest
+statefully, thus not sending cookies, or by using the same cookie construction
+for all backend servers.
+
+Note that, if the cookie includes a key name, analogous to Section 4 of
+{{?RFC5077}}, this may leak information if different backend servers issue
+cookies with different key names at the time of the connection. In particular,
+if the deployment operates in Split Mode, the backend servers may not share
+cookie encryption keys. Backend servers may mitigate this by either handling
+key rotation with trial decryption, or coordinating to match key names.
+
+[[OPEN ISSUE: If we land #422, replace "These values are sent unencrypted in
+ECH" with "While ECH encrypts the cookie in the second ClientHelloInner, the
+backend server's HelloRetryRequest is unencrypted."]]
+
 ## Attacks Exploiting Acceptance Confirmation
 
 To signal acceptance, the backend server overwrites 8 bytes of its

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1275,10 +1275,6 @@ if the deployment operates in Split Mode, the backend servers may not share
 cookie encryption keys. Backend servers may mitigate this by either handling
 key rotation with trial decryption, or coordinating to match key names.
 
-[[OPEN ISSUE: If we land #422, replace "These values are sent unencrypted in
-ECH" with "While ECH encrypts the cookie in the second ClientHelloInner, the
-backend server's HelloRetryRequest is unencrypted."]]
-
 ## Attacks Exploiting Acceptance Confirmation
 
 To signal acceptance, the backend server overwrites 8 bytes of its

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1256,7 +1256,7 @@ client previously connected to and which is within the same anonymity set.
 
 ## Cookies
 
-Section 4.2.2 of {{RFC8446}} defines a cookie value that servers may send in
+{{Section 4.2.2 of RFC8446}} defines a cookie value that servers may send in
 HelloRetryRequest for clients to echo in the second ClientHello. These values
 are sent unencrypted in ECH. This means differences in cookies between backend
 servers, such as lengths or cleartext components, may leak information about

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1257,10 +1257,11 @@ client previously connected to and which is within the same anonymity set.
 ## Cookies
 
 {{Section 4.2.2 of RFC8446}} defines a cookie value that servers may send in
-HelloRetryRequest for clients to echo in the second ClientHello. These values
-are sent unencrypted in ECH. This means differences in cookies between backend
-servers, such as lengths or cleartext components, may leak information about
-the server identity.
+HelloRetryRequest for clients to echo in the second ClientHello. While ECH
+encrypts the cookie in the second ClientHelloInner, the backend server's
+HelloRetryRequest is unencrypted.This means differences in cookies between
+backend servers, such as lengths or cleartext components, may leak information
+about the server identity.
 
 Backend servers in an anonymity set SHOULD NOT reveal information in the cookie
 which identifies the server. This may be done by handling HelloRetryRequest


### PR DESCRIPTION
One of the motivations for encrypting HRR in #407 was the leaks from cookie values. If we don't go with such a construction (which seems likely) and instead do #417 or #422, cookies will be in the clear. That means it is instead on the backend servers to construct cookie values without leaking information. This PR provides security considerations to that effect.

Unfortunately the requirements on backend servers within a Split Mode deployment are a bit onerous. I suspect, in practice, the answer is that Split Mode deployments cannot even use cookies on the backend server. Between HRRs being rare and stateless HRR being unnecessary over TCP or QUIC, that's hopefully fine. (Note this is different from #418, which was about the *client-facing* server being stateless. This applies if the *backend* server is stateless.)