### PR TITLE
Move ClientHello padding to the encoding.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -455,9 +455,9 @@ extensions MUST be ordered consecutively in ClientHelloInner. The list of outer
 extensions, OuterExtensions, includes those which were removed from
 EncodedClientHelloInner, in the order in which they were removed.
 
-Finally, the client determines the number of padding bytes, N, and sets the
-`zeros` field to a byte string whose contents are N zeros. {{padding}}
-describes a recommended padding scheme.
+Finally, the client pads the message by setting the `zeros` field to a byte
+string whose contents are all zeros and whose length is the amount of padding
+to add. {{padding}} describes a recommended padding scheme.
 
 The client-facing server computes ClientHelloInner by reversing this process.
 First it parses EncodedClientHelloInner, interpreting all bytes after

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -438,15 +438,15 @@ which is the following structure:
 ~~~
     struct {
         ClientHello client_hello;
-        opaque padding[N];
+        uint8 zeros[length_of_padding];
     } EncodedClientHelloInner;
 ~~~
 
 The `client_hello` field is computed by first making a copy of ClientHelloInner
 and setting the `legacy_session_id` field to the empty string. Note this field
 uses the ClientHello structure, defined in {{Section 4.1.2 of RFC8446}} which
-does not include the Handshake structure's four byte header. The `padding`
-field MUST be all zeroes.
+does not include the Handshake structure's four byte header. The `zeros` field
+MUST be all zeroes.
 
 The client then MAY substitute extensions which it knows will be duplicated in
 ClientHelloOuter. To do so, the client removes and replaces extensions from
@@ -455,9 +455,9 @@ extensions MUST be ordered consecutively in ClientHelloInner. The list of outer
 extensions, OuterExtensions, includes those which were removed from
 EncodedClientHelloInner, in the order in which they were removed.
 
-Finally, the client determines the number of padding bytes, N, and sets
-the `padding` field to a byte string whose contents are N zeros.
-{{padding}} describes a recommended padding scheme.
+Finally, the client determines the number of padding bytes, N, and sets the
+`zeros` field to a byte string whose contents are N zeros. {{padding}}
+describes a recommended padding scheme.
 
 The client-facing server computes ClientHelloInner by reversing this process.
 First it parses EncodedClientHelloInner, interpreting all bytes after

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -696,7 +696,7 @@ value.
 1. If the ClientHelloInner contained a "server_name" extension with a name of
    length D, add max(0, L - D) bytes of padding.
 2. If the ClientHelloInner did not contain a "server_name" extension (e.g., if
-   the client is connecting to an IP address), add L + 7 bytes of padding. This
+   the client is connecting to an IP address), add L + 9 bytes of padding. This
    is the length of a "server_name" extension with an L-byte name.
 
 Finally, the client SHOULD pad the entire message as follows:

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -691,7 +691,7 @@ value.
 
 1. If the ClientHelloInner contained a "server_name" extension with a name of
    length D, add max(0, L - D) bytes of padding.
-2. If the ClientHelloInner did not contain a "server_name" extension (e.g. if
+2. If the ClientHelloInner did not contain a "server_name" extension (e.g., if
    the client is connecting to an IP address), add L + 7 bytes of padding. This
    is the length of a "server_name" extension with an L-byte name.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -422,7 +422,7 @@ which is the following structure:
 ~~~
     struct {
         ClientHello client_hello;
-        opaque padding<0..2^16-1>;
+        opaque padding[N];
     } EncodedClientHelloInner;
 ~~~
 
@@ -443,8 +443,9 @@ Finally, the client sets the `padding` field to a byte string whose contents
 are all zeros. {{padding}} describes a recommended padding scheme.
 
 The client-facing server computes ClientHelloInner by reversing this process.
-First it makes a copy of the `client_hello` field and copies the
-`legacy_session_id` field from ClientHelloOuter. It then looks for an
+First it parses EncodedClientHelloInner, interpreting all bytes after
+`client_hello` as padding. Next it makes a copy of the `client_hello` field and
+copies the `legacy_session_id` field from ClientHelloOuter. It then looks for an
 "ech_outer_extensions" extension. If found, it replaces the extension with the
 corresponding sequence of extensions in the ClientHelloOuter. If any referenced
 extensions are missing or if "encrypted_client_hello" appears in the list, the

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -428,9 +428,9 @@ which is the following structure:
 
 The `client_hello` field is computed by first making a copy of
 ClientHelloInner with the `legacy_session_id` field with an empty string.
-Note this field uses the ClientHello structure, defined in Section 4.1.2
-of {{RFC8446}} which does not include the Handshake structure's four byte
-header.
+Note this field uses the ClientHello structure, defined in {{Section 4.1.2
+of RFC8446}} which does not include the Handshake structure's four byte
+header. The `padding` field MUST be all zeroes.
 
 The client then MAY substitute extensions which it knows will be duplicated in
 ClientHelloOuter. To do so, the client removes and replaces extensions from

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -439,8 +439,9 @@ extensions MUST be ordered consecutively in ClientHelloInner. The list of outer
 extensions, OuterExtensions, includes those which were removed from
 EncodedClientHelloInner, in the order in which they were removed.
 
-Finally, the client sets the `padding` field to a byte string whose contents
-are all zeros. {{padding}} describes a recommended padding scheme.
+Finally, the client determines the number of padding bytes, N, and sets
+the `padding` field to a byte string whose contents are N zeros.
+{{padding}} describes a recommended padding scheme.
 
 The client-facing server computes ClientHelloInner by reversing this process.
 First it parses EncodedClientHelloInner, interpreting all bytes after
@@ -703,7 +704,7 @@ Finally, the client SHOULD pad the entire message as follows:
 
 1. Let L be the length of the EncodedClientHelloInner with all the padding
    computed so far.
-2. Let P = 31 - ((L - 1) % 32) and add P bytes of padding.
+2. Let N = 31 - ((L - 1) % 32) and add N bytes of padding.
 
 This rounds the length of EncodedClientHelloInner up to a multiple of 32 bytes,
 reducing the set of possible lengths across all clients.


### PR DESCRIPTION
Closes #433. This PR does four things:

1. Apply the EncodedClientHelloInner change suggested in #433.

2. Adjust the recommended padding scheme to round the overall length to
   a multiple of 32, now that this is fairly easy to compute.

3. It fixes an mistake in the recommended padding scheme. The server
   sets maximum_name_length to the longest *name*, but the client
   computes padding based on the server_name *extension*. We're
   miscounting 7 bytes of extension overhead and effectively are using
   maximum_name_length - 7 instead of maximum_name_length.

4. It defines what to do if you aren't sending SNI. While unlikely to
   happen in practice (no way to get an ECHConfig), implementations will
   need to handle this. The application may well call SetECHConfigList()
   without SetServerName() and it's rude to crash. It's pretty obvious what
   to do, so just define it.

(If folks would rather the PR only do a subset of these, I can defer the more controversial bits to other PRs. They all touched the same text, so it was easier to just do them all.)