### PR TITLE
Allow empty enc in ClientECH.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -357,7 +357,7 @@ The payload MUST have the following structure:
     struct {
        HpkeSymmetricCipherSuite cipher_suite;
        uint8 config_id;
-       opaque enc<1..2^16-1>;
+       opaque enc<0..2^16-1>;
        opaque payload<1..2^16-1>;
     } ClientECH;
 ~~~~
@@ -371,7 +371,8 @@ provided in the corresponding `ECHConfigContents.cipher_suites` list.
 
 enc
 : The HPKE encapsulated key, used by servers to decrypt the corresponding
-`payload` field.
+`payload` field. This field is empty in ClientHelloOuters sent in response to
+HelloRetryRequest.
 
 payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE


### PR DESCRIPTION
The second ClientHello after HelloRetryRequest reuses the HPKE context
and calls Seal/Open a second time. To avoid needing to unnecessarily
retain the enc value, and discourage servers from mistakenly recreating
the HPKE context, we made it use the empty string but forgot to update
the syntax to match.