### PR TITLE
Rephrase maximum_name_length description.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -268,11 +268,10 @@ which could include any ECHConfig that has been recently removed from active
 use.
 
 maximum_name_length
-: The longest name of a backend server, if known. If this value is not known it
-can be set to zero, in which case clients SHOULD use the inner ClientHello
-padding scheme described below. That could happen if wildcard names are in use,
-or if names can be added or removed from the anonymity set during the lifetime
-of a particular ECH configuration.
+: The longest name of a backend server, if known. If not known, this value can
+be set to zero. It is used to compute padding ({{padding}}) and does not
+constrain the lengths of server names. Names may exceed this length if, e.g.,
+the server uses wildcard names or added new names to the anonymity set.
 
 public_name
 : The non-empty name of the client-facing server, i.e., the entity trusted to

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -270,7 +270,7 @@ use.
 maximum_name_length
 : The longest name of a backend server, if known. If not known, this value can
 be set to zero. It is used to compute padding ({{padding}}) and does not
-constrain the lengths of server names. Names may exceed this length if, e.g.,
+constrain server name lengths. Names may exceed this length if, e.g.,
 the server uses wildcard names or added new names to the anonymity set.
 
 public_name


### PR DESCRIPTION
While padding is "described below", it's pretty far away now. We also
recommend the padding scheme whether or not the value is non-zero. The
text about wildcard names also applies in both cases and seems to
describe when the server name may exceed the max.

This rephases things a bit.