### PR TITLE
Make ECHConfig.version match the codepoint

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -241,7 +241,7 @@ The ECH configuration is defined by the following `ECHConfig` structure.
         uint16 version;
         uint16 length;
         select (ECHConfig.version) {
-          case 0xfe0a: ECHConfigContents contents;
+          case 0xfe0b: ECHConfigContents contents;
         }
     } ECHConfig;
 ~~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -241,7 +241,7 @@ The ECH configuration is defined by the following `ECHConfig` structure.
         uint16 version;
         uint16 length;
         select (ECHConfig.version) {
-          case 0xfe0b: ECHConfigContents contents;
+          case 0xfe0c: ECHConfigContents contents;
         }
     } ECHConfig;
 ~~~~
@@ -358,7 +358,7 @@ ClientHelloInner.
 
 ~~~
     enum {
-       encrypted_client_hello(0xfe0b), (65535)
+       encrypted_client_hello(0xfe0c), (65535)
     } ExtensionType;
 ~~~
 
@@ -1589,7 +1589,7 @@ ClientHello vulnerable to an analogue of this attack.
 IANA is requested to create the following three entries in the existing registry
 for ExtensionType (defined in {{!RFC8446}}):
 
-1. encrypted_client_hello(0xfe0b), with "TLS 1.3" column values set to
+1. encrypted_client_hello(0xfe0c), with "TLS 1.3" column values set to
    "CH, HRR, EE", and "Recommended" column set to "Yes".
 1. ech_outer_extensions(0xfd00), with the "TLS 1.3" column values set to "",
    and "Recommended" column set to "Yes".


### PR DESCRIPTION
To be included with #463.

Note that this is a wire-breaking change that should have landed in draft-11, but didn't.