### PR TITLE
Don't require OuterExtensions de-duplication

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -479,8 +479,6 @@ are true:
 
 * "encrypted_client_hello" appears in OuterExtensions.
 
-* OuterExtensions contains duplicate values.
-
 * The extensions in ClientHelloOuter corresponding to those in OuterExtensions
   do not occur in the same order.
 


### PR DESCRIPTION
There are two reasons for this. First, the algorithm in Appendix B for
decoding the EncodedClientHelloInner doesn't actually enforce this.
Second, aborting on duplicated extensions is slightly stricter than RFC
8446 requires. It states that "[t]here MUST NOT be more than one
extension of the same type in a given extension block", but doesn't
specify what the receiver does in this case.