### PR TITLE
Revise middlebox section.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1128,21 +1128,16 @@ DNS results, if one is provided.
 
 ## Middleboxes
 
-A more serious problem is MITM proxies which do not support this extension.
-{{RFC8446, Section 9.3}} requires that such proxies remove any extensions they
-do not understand. The handshake will then present a certificate based on the
-public name, without echoing the "encrypted_client_hello" extension to the
-client.
+{{RFC8446, Section 9.3}} requires TLS-terminating proxies ignore unknown
+parameters, and generate their own ClientHello containing only parameters they
+understand. Thus, when presenting a certificate to the client or sending a
+ClientHello to the server, the proxy will act as if connecting to the public
+name, without echoing the "encrypted_client_hello" extension.
 
 Depending on whether the client is configured to accept the proxy's certificate
 as authoritative for the public name, this may trigger the retry logic described
 in {{handle-server-response}} or result in a connection failure. A proxy which
 is not authoritative for the public name cannot forge a signal to disable ECH.
-
-A non-conformant MITM proxy which instead forwards the ECH extension,
-substituting its own KeyShare value, will result in the client-facing server
-recognizing the key, but failing to decrypt the SNI. This causes a hard failure.
-Clients SHOULD NOT attempt to repair the connection in this case.
 
 # Compliance Requirements {#compliance}
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1128,11 +1128,13 @@ DNS results, if one is provided.
 
 ## Middleboxes
 
-{{RFC8446, Section 9.3}} requires TLS-terminating proxies ignore unknown
-parameters, and generate their own ClientHello containing only parameters they
-understand. Thus, when presenting a certificate to the client or sending a
-ClientHello to the server, the proxy will act as if connecting to the public
-name, without echoing the "encrypted_client_hello" extension.
+When connecting through a TLS-terminating proxy that does not support this
+extension, {{RFC8446, Section 9.3}} requires the proxy still act as a
+conforming TLS client and server. The proxy must ignore unknown parameters, and
+generate its own ClientHello containing only parameters it understands. Thus,
+when presenting a certificate to the client or sending a ClientHello to the
+server, the proxy will act as if connecting to the public name, without echoing
+the "encrypted_client_hello" extension.
 
 Depending on whether the client is configured to accept the proxy's certificate
 as authoritative for the public name, this may trigger the retry logic described


### PR DESCRIPTION
Closes #474. This makes a few changes to the middlebox section:

First, using "MITM proxies" when RFC8446 talks about terminating TLS was
confusing, so align with the RFC8446 terminology.

Next, RFC8446 does not quite require dropping unknown extensions, only
generating your own ClientHello. Dropping unknown extensions happens if
the proxy tries to intersect its true capabilities with that of the
client. I've also dropped the "a more serious problem" introduction
since the point of this section is that it's not a serious problem.

Finally, I've dropped the "non-conformant MITM proxy" paragraph. It's
slightly out of date now that we've unified everything around trial
decryption. I believe, depending on what the proxy does with the
server's EncryptedExtensions response, things will either break, work on
accident, or retry loop and hit the limit. It doesn't seem worth
expending a whole lot of text on something that is the proxy's fault.

This does drop the "Clients SHOULD NOT attempt to repair the connection
in this case" line, but the client couldn't really detect this case
anyway. It looks like any old connection failure without a proxy, and
the usual considerations for changing your TLS config on connection
failure apply.