### PR TITLE
Tidy up client ECH accept and GREASE sections

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -600,7 +600,7 @@ offered in the ClientHelloOuter. See {{outer-clienthello}} for additional
 guidance.
 
 Finally, the client encrypts the EncodedClientHelloInner with the above values,
-as described in {{encrypting-clienthello}}, to consctruct a ClientHelloOuter. It
+as described in {{encrypting-clienthello}}, to construct a ClientHelloOuter. It
 sends this to the server, and processes the response as described in
 {{determining-ech-acceptance}}.
 
@@ -770,18 +770,13 @@ ClientHello message as follows:
    uses a fresh nonce for each AEAD operation. Reusing the HPKE context avoids
    an attack described in {{flow-hrr-hijack}}.
 
-Note this procedure does not apply {{Section 4.1.4 of RFC8446}} to the
-ClientHelloOuter, only ClientHelloInner. The server generates HelloRetryRequest
-from ClientHelloInner. If the ClientHelloOuter and ClientHelloInner expressed
-different preferences, applying the standard procedure to ClientHelloOuter may
-not succeed.
 
 The client then sends the second ClientHelloOuter to the server. However, as
-above, it uses the second ClientHelloInner for preferences and the transcript
-hash. Additionally, it checks the resulting ServerHello for ECH acceptance as in
-{{determining-ech-acceptance}}. If the ServerHello does not also indicate ECH
-acceptance, the client MUST terminate the connection with an "illegal_parameter"
-alert.
+above, it uses the second ClientHelloInner for preferences, and both the
+ClientHelloInner messages for the transcript hash. Additionally, it checks the
+resulting ServerHello for ECH acceptance as in {{determining-ech-acceptance}}.
+If the ServerHello does not also indicate ECH acceptance, the client MUST
+terminate the connection with an "illegal_parameter" alert.
 
 ### Handshaking with ClientHelloOuter {#rejected-ech}
 


### PR DESCRIPTION
This PR cleans up the client text, in hopes of making it more precise
and organized somewhat more chronologically. It then uses this cleanup
to clarify bits we forgot to write down in the accept/reject/HRR
machinery:

1. Handling the Server Response is now Determining ECH Acceptance and
   only discusses the initial accept/reject decision.

2. The portion of Handling HelloRetryRequest discussing the
   accept/reject decision is moved to Determining ECH Acceptence.

3. Determining ECH Acceptance is tidied up to discuss to what happens if
   you see an older TLS version (it's a reject). In particular, in DTLS
   1.2, the first server message might be HelloVerifyRequest and not
   ServerHello or HelloRetryRequest.

4. Accepted/Rejected ECH are now Handshaking with
   ClientHelloInner/ClientHelloOuter to fit with the other section names
   (lots of VERBing). They are unindented from (1) because that section
   only talks about the accept/reject decision. This gives us a place to
   discuss *all* changes to the handshake. We describe what it actually
   means to handshake with ClientHelloInner, including implications to
   the transcript. And...

5. ...the portion of Handling HelloRetryRequest that discussed
   constructing the second ClientHello never applied to the ECH Reject
   case anyway, only ECH Accept. Move this to (4). Also expand on it so
   it's a bit more clearly defined. I've also moved HPKE setup out of
   Encrypting the ClientHello, as that's only relevant to one of the two
   "callers" anyway. I'm not thrilled with this notion of "partial
   ClientHelloOuterAAD", but the text used in Offering ECH and
   Encrypting the ClientHello sections otherwise doesn't actually match.
   Before this PR, both think they are responsible for constructing
   ClientHelloOuter.

6. With this and (1), Handling HelloRetryRequest is
   now empty and removed.

7. We forgot to write down the client half of
   https://github.com/tlswg/draft-ietf-tls-esni/pull/461. There is now a
   place for it in Handshaking with ClientHelloInner.

8. We say that the ECH reject case ignores the HRR.ech extension, so ECH
   GREASE says the same thing, to keep them aligned.

The Handshaking with ClientHelloOuter section could also do with an
editorial pass, but I've omitted it from this PR because it was getting
a bit large as it is.