### PR TITLE
redundant length

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -228,7 +228,9 @@ draft-08, the version is the same as the code point for the
 structure with a version they do not support.
 
 length
-: The length, in bytes, of the next field.
+: The length, in bytes, of the next field. This field is redundant,
+as only one ECHConfigContents can currently be present in an ECHConfig,
+but is provided for future-proofing.
 
 contents
 : An opaque byte string whose contents depend on the version. For this


### PR DESCRIPTION
ECHConfig.length is either redundant or else it needs more explanation. This PR assumes the former. Either's fine by me (my draft-10 code supports >1 key per supplied ECHConfig for obscure API reasons anyway:-). This change notes that the field is currently redundant as there's only one ECHConfigContents per ECHConfig.  If we want to allow >1 ECHConfigContents per ECHConfig then we should say that explicitly here and likely somewhere else too. 

I'd have to look again at the SVCB spec but I think this being redundant also means that a deployment needs to have >1 HTTPS/SVCB RR value to publish more than one key at a time. If that's correct it may be worth noting here somewhere too.