### PR TITLE
Clarify a bit why server might send retry configs

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When the client offers the "encrypted_client_hello" extension, if the payload
-is the outer variant, then the server MAY include an "encrypted_client_hello"
+When a client offers the `outer` version of an "encrypted_client_hello" extension, 
+then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,9 +374,10 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When a client offers the `outer` version of an "encrypted_client_hello" extension, 
-then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
-extension in its EncryptedExtensions message with the following payload:
+When a client offers the `outer` version of an "encrypted_client_hello"
+extension, the server MAY include an "encrypted_client_hello" extension in its
+EncryptedExtensions message, as described in {{client-facing-server}}, with the
+following payload:
 
 ~~~
     struct {


### PR DESCRIPTION
Current text seemed a bit opaque as to why a server might send retry configs.