### PR TITLE
Try clarify an odd MUST in 6.1.5

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -757,10 +757,10 @@ ClientHello message as follows:
 1. It constructs EncodedClientHelloInner as described in {{encoding-inner}}.
 
 1. It constructs a second partial ClientHelloOuterAAD. This MUST be constructed
-   as described in {{encrypting-clienthello}} with an empty `enc` field. The
-   extensions MAY be copied from the original ClientHelloOuter unmodified, or
-   omitted. If not sensitive, the client MAY copy updated extensions from the
-   second ClientHelloInner for compression.
+   afresh as described in {{encrypting-clienthello}}. The extensions MAY be copied
+   from the original ClientHelloOuter unmodified, or omitted. If not sensitive,
+   the client MAY copy updated extensions from the second ClientHelloInner for
+   compression.
 
 1. It encrypts EncodedClientHelloInner as described in
    {{encrypting-clienthello}}, using the second partial ClientHelloOuterAAD, to

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -214,7 +214,7 @@ The ECH configuration is defined by the following `ECHConfig` structure.
         uint16 version;
         uint16 length;
         select (ECHConfig.version) {
-          case 0xfe0c: ECHConfigContents contents;
+          case 0xfe0d: ECHConfigContents contents;
         }
     } ECHConfig;
 ~~~~
@@ -331,7 +331,7 @@ ClientHelloInner.
 
 ~~~
     enum {
-       encrypted_client_hello(0xfe0c), (65535)
+       encrypted_client_hello(0xfe0d), (65535)
     } ExtensionType;
 ~~~
 
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When the client offers the "encrypted_client_hello" extension, if the payload
-is the outer variant, then the server MAY include an "encrypted_client_hello"
+When the client offers the "encrypted_client_hello" extension, if the payload is
+the `outer` variant, then the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~
@@ -1619,7 +1619,7 @@ ClientHello vulnerable to an analogue of this attack.
 IANA is requested to create the following three entries in the existing registry
 for ExtensionType (defined in {{!RFC8446}}):
 
-1. encrypted_client_hello(0xfe0c), with "TLS 1.3" column values set to
+1. encrypted_client_hello(0xfe0d), with "TLS 1.3" column values set to
    "CH, HRR, EE", and "Recommended" column set to "Yes".
 1. ech_outer_extensions(0xfd00), with the "TLS 1.3" column values set to "",
    and "Recommended" column set to "Yes".

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When the client offers the "encrypted_client_hello" extension, if the payload is
-the `outer` variant, then the server MAY include an "encrypted_client_hello"
+When a client offers the `outer` version of an "encrypted_client_hello" extension, 
+then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When a client offers the `outer` version of an "encrypted_client_hello" extension, 
-then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
+When the client offers the "encrypted_client_hello" extension, if the payload
+is the outer variant, then the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -756,10 +756,11 @@ ClientHello message as follows:
 
 1. It constructs EncodedClientHelloInner as described in {{encoding-inner}}.
 
-1. It constructs a second partial ClientHelloOuterAAD message. This message MUST
-   be syntactically valid. The extensions MAY be copied from the original
-   ClientHelloOuter unmodified, or omitted. If not sensitive, the client MAY
-   copy updated extensions from the second ClientHelloInner for compression.
+1. It constructs a second partial ClientHelloOuterAAD. This MUST be constructed
+   as described in {{encrypting-clienthello}} with an empty `enc` field. The
+   extensions MAY be copied from the original ClientHelloOuter unmodified, or
+   omitted. If not sensitive, the client MAY copy updated extensions from the
+   second ClientHelloInner for compression.
 
 1. It encrypts EncodedClientHelloInner as described in
    {{encrypting-clienthello}}, using the second partial ClientHelloOuterAAD, to


### PR DESCRIPTION
6.1.5 says "This message MUST be syntactically valid." I'm not entirely sure what was intended there, so took a stab at clarifying. In any case as-is that sentence doesn't really seem to say anything useful.

My suggestion assumes that enc is included as part of the ECH in the AAD used with HRR. Given we omit enc from the 2nd ECH as-sent that seems a bit wrong so may need a few more words.

Note that the next bullet talks about using the "emtpy string for enc" - not sure if "empty string" precise enough but if we omit enc from both AAD and ECH (during HRR) we may need align how we describe things. 