### PR TITLE
retry configs: tweak about subsequent connections 

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -795,11 +795,12 @@ If at least one of the values contains a version supported by the client, it can
 regard the ECH keys as securely replaced by the server. It SHOULD retry the
 handshake with a new transport connection, using the retry configurations
 supplied by the server. The retry configurations may only be applied to the
-retry connection. The client MUST continue to use the previously-advertised
-configurations for subsequent connections. This avoids introducing pinning
-concerns or a tracking vector, should a malicious server present
-client-specific retry configurations in order to identify the client in a
-subsequent ECH handshake.
+retry connection. The client MUST only use a retry configuration for subsequent
+connections for a short (client-defined) duration and MUST revert to use the
+previously-advertised configurations after that duration has passed.  This
+avoids introducing pinning concerns or a tracking vector, should a malicious
+server present client-specific retry configurations in order to identify the
+client in a subsequent ECH handshake.
 
 If none of the values provided in "retry_configs" contains a supported version,
 the client can regard ECH as securely disabled by the server. As below, it

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -214,7 +214,7 @@ The ECH configuration is defined by the following `ECHConfig` structure.
         uint16 version;
         uint16 length;
         select (ECHConfig.version) {
-          case 0xfe0c: ECHConfigContents contents;
+          case 0xfe0d: ECHConfigContents contents;
         }
     } ECHConfig;
 ~~~~
@@ -331,7 +331,7 @@ ClientHelloInner.
 
 ~~~
     enum {
-       encrypted_client_hello(0xfe0c), (65535)
+       encrypted_client_hello(0xfe0d), (65535)
     } ExtensionType;
 ~~~
 
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When the client offers the "encrypted_client_hello" extension, if the payload
-is the outer variant, then the server MAY include an "encrypted_client_hello"
+When the client offers the "encrypted_client_hello" extension, if the payload is
+the `outer` variant, then the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~
@@ -1619,7 +1619,7 @@ ClientHello vulnerable to an analogue of this attack.
 IANA is requested to create the following three entries in the existing registry
 for ExtensionType (defined in {{!RFC8446}}):
 
-1. encrypted_client_hello(0xfe0c), with "TLS 1.3" column values set to
+1. encrypted_client_hello(0xfe0d), with "TLS 1.3" column values set to
    "CH, HRR, EE", and "Recommended" column set to "Yes".
 1. ech_outer_extensions(0xfd00), with the "TLS 1.3" column values set to "",
    and "Recommended" column set to "Yes".

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When the client offers the "encrypted_client_hello" extension, if the payload is
-the `outer` variant, then the server MAY include an "encrypted_client_hello"
+When a client offers the `outer` version of an "encrypted_client_hello" extension, 
+then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -795,12 +795,10 @@ If at least one of the values contains a version supported by the client, it can
 regard the ECH keys as securely replaced by the server. It SHOULD retry the
 handshake with a new transport connection, using the retry configurations
 supplied by the server. The retry configurations may only be applied to the
-retry connection. The client MUST only use a retry configuration for subsequent
-connections for a short (client-defined) duration and MUST revert to use the
-previously-advertised configurations after that duration has passed.  This
-avoids introducing pinning concerns or a tracking vector, should a malicious
-server present client-specific retry configurations in order to identify the
-client in a subsequent ECH handshake.
+retry connection. The client MUST NOT use retry configurations for connections
+beyond the retry. This avoids introducing pinning concerns or a tracking 
+vector, should a malicious server present client-specific retry configurations
+in order to identify the client in a subsequent ECH handshake.
 
 If none of the values provided in "retry_configs" contains a supported version,
 the client can regard ECH as securely disabled by the server. As below, it

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -374,8 +374,8 @@ payload
 : The serialized and encrypted ClientHelloInner structure, encrypted using HPKE
 as described in {{real-ech}}.
 
-When a client offers the `outer` version of an "encrypted_client_hello" extension, 
-then, for example if decryption fails, the server MAY include an "encrypted_client_hello"
+When the client offers the "encrypted_client_hello" extension, if the payload
+is the outer variant, then the server MAY include an "encrypted_client_hello"
 extension in its EncryptedExtensions message with the following payload:
 
 ~~~


### PR DESCRIPTION
When retry-configs are defined in section 5 we say they are for "subsequent connection attempts" but in 6.1.6 we have a MUST NOT for using those for "subsequent connections." That seems inconsistent and maybe even wrong if one thinks about how e.g. wget can crawl web pages, or how applications might use libcurl, so this change tries to fix that. Not sure if short duration is the right way to phrase it though.