### PR TITLE
Clarify ambiguous grammar

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -930,8 +930,8 @@ Some uses of ECH, such as local discovery mode, may randomize the
 ECHClientHello.config_id since it can be used as a tracking vector. In such
 cases, the second method should be used for matching the ECHClientHello to a
 known ECHConfig. See {{optional-configs}}. Unless specified by the application
-using (D)TLS or externally configured on both sides, implementations MUST use
-the first method.
+profile or otherwise externally configured on both sides, implementations MUST
+use the first method.
 
 The server then iterates over the candidate ECHConfig values, attempting to
 decrypt the "encrypted_client_hello" extension:


### PR DESCRIPTION
As previously written, the wording could be understood as referring to
an application using some other (D)TLS mechanism to indicate which
ECHConfig candidate value selection method to use.