### PR TITLE
Abort on duplicate OuterExtensions

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -495,7 +495,9 @@ are true:
 
 * Any referenced extension is missing in ClientHelloOuter.
 
-* "encrypted_client_hello" appears in OuterExtensions.
+* Any extension is referenced in OuterExtensions more than once.
+
+* "encrypted_client_hello" is referenced in OuterExtensions.
 
 * The extensions in ClientHelloOuter corresponding to those in OuterExtensions
   do not occur in the same order.
@@ -1725,7 +1727,8 @@ application layer.
 # Linear-time Outer Extension Processing {#linear-outer-extensions}
 
 The following procedure processes the "ech_outer_extensions" extension (see
-{{encoding-inner}}) in linear time:
+{{encoding-inner}}) in linear time, ensuring that each extension in the
+ClientHelloOuter is included at most once:
 
 1. Let I be zero and N be the number of extensions in ClientHelloOuter.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1727,7 +1727,7 @@ application layer.
 # Linear-time Outer Extension Processing {#linear-outer-extensions}
 
 The following procedure processes the "ech_outer_extensions" extension (see
-{{encoding-inner}}) in linear time, ensuring that each extension in the
+{{encoding-inner}}) in linear time, ensuring that each referenced extension in the
 ClientHelloOuter is included at most once:
 
 1. Let I be zero and N be the number of extensions in ClientHelloOuter.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -502,6 +502,10 @@ are true:
 * The extensions in ClientHelloOuter corresponding to those in OuterExtensions
   do not occur in the same order.
 
+These requirements prevent an attacker from performing a packet amplification
+attack, by crafting a ClientHelloOuter which decompresses to a much larger
+ClientHelloInner. This is discussed further in {{decompression-amp}}.
+
 Implementations SHOULD bound the time to compute a ClientHelloInner
 proportionally to the ClientHelloOuter size. If the cost is disproportionately
 large, a malicious client could exploit this in a denial of service attack.
@@ -1640,7 +1644,7 @@ ClientHelloInner and authenticating all inputs to the ClientHelloInner
 encrypted and authenticated the "server_name" extension, which left the overall
 ClientHello vulnerable to an analogue of this attack.
 
-### ClientHelloInner Packet Amplification Mitigation
+### ClientHelloInner Packet Amplification Mitigation {#decompression-amp}
 
 Client-facing servers must decompress EncodedClientHelloInners. A malicious
 attacker may craft a packet which takes excessive resources to decompress
@@ -1651,12 +1655,13 @@ or may be much larger than the incoming packet:
   M is the number of extensions in ClientHelloOuter and N is the
   size of OuterExtensions.
 
-* If OuterExtensions contains duplicate extensions, an attacker could cause the
-  client-facing server to construct a large ClientHelloInner by including a
-  large extension in ClientHelloOuter, of length L, and an OuterExtensions
-  list referencing N copies of that extension. The client-facing server would
-  then use O(N\*L) memory in response to O(N+L) bandwidth from the client. In
-  split-mode, an O(N\*L) sized packet would then be transmitted to the
+* If the same ClientHelloOuter extension can be copied multiple times,
+  an attacker could cause the client-facing server to construct a large
+  ClientHelloInner by including a large extension in ClientHelloOuter,
+  of length L, and an OuterExtensions list referencing N copies of that
+  extension. The client-facing server would then use O(N\*L) memory in
+  response to O(N+L) bandwidth from the client. In split-mode, an
+  O(N\*L) sized packet would then be transmitted to the
   backend server.
 
 ECH mitigates this attack by requiring that OuterExtensions be referenced in

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1660,7 +1660,7 @@ or may be much larger than the incoming packet:
   backend server.
 
 ECH mitigates this attack by requiring that OuterExtensions be referenced in
-order, that duplicate references be rejected and by recommending that
+order, that duplicate references be rejected, and by recommending that
 client-facing servers use a linear scan to perform decompression. These
 requirements are detailed in {{encoding-inner}}.
 


### PR DESCRIPTION
If OuterExtensions contains duplicate references to the same extension in the ClientHelloOuter, a draft-compliant implementation may create a ClientHelloInner many times larger than the received ClientHelloOuter. In split mode, this allows for network DoS via packet amplification. In shared mode, this could lead to memory or CPU exhaustion. 

This PR requires implementions to reject OuterExtensions which reference the same extension more than once. This can be achieved in practice by using the algorithm suggested in Appendix B. 