### PR TITLE
TCP is not the only transport

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1412,7 +1412,7 @@ values with different keys using a short TTL.
 This design requires servers to decrypt ClientHello messages with ECHClientHello
 extensions carrying valid digests. Thus, it is possible for an attacker to force
 decryption operations on the server. This attack is bound by the number of valid
-TCP connections an attacker can open.
+transport connections an attacker can open.
 
 ### Do Not Stick Out {#dont-stick-out}
 


### PR DESCRIPTION
Closes #551 

I realize that QUIC, being a transport that inlines TLS, would not immediately apply here, but I think the intent is generic enough to not be confusing or misleading. Plus, this was literally the only place we used "TCP," whereas elsewhere we use "transport connection," so this is also for consistency.

cc @dennisjackson, @davidben, @cjpatton 