### PR TITLE
Clarify attacker capabilities

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1206,10 +1206,10 @@ between the client and client-facing server, as well as between the
 client-facing and backend servers when running ECH in Split Mode. However,
 for Split Mode in particular, ECH makes two additional assumptions:
 
-1. The channel between each client-facing and each backend server is authenticated
-such that the backend server only accepts messages from trusted client-facing
-servers. The exact mechanism for establishing this authenticated channel is
-out of scope for this document.
+1. The channel between each client-facing and each backend server is
+authenticated such that the backend server only accepts messages from trusted
+client-facing servers. The exact mechanism for establishing this authenticated
+channel is out of scope for this document.
 1. The attacker cannot correlate messages between client and client-facing
 server with messages between client-facing and backend server. Such correlation
 could allow an attacker to link information unique to a backend server, such as

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -114,7 +114,8 @@ notation comes from {{RFC8446, Section 3}}.
 # Overview
 
 This protocol is designed to operate in one of two topologies illustrated below,
-which we call "Shared Mode" and "Split Mode".
+which we call "Shared Mode" and "Split Mode". These modes are described in the
+following section.
 
 ## Topologies
 
@@ -1203,15 +1204,20 @@ for TLS 1.3 {{RFC8446}}.
 Passive and active attackers can exist anywhere in the network, including
 between the client and client-facing server, as well as between the
 client-facing and backend servers when running ECH in Split Mode. However,
-for Split Mode in particular, ECH assumes that the attacker cannot correlate
-messages between client and client-facing server with messages between
-client-facing and backend server. Such correlation could allow an attacker
-to link information unique to a backend server, such as their server name
-or IP address, with a client's encrypted ClientHelloInner. Such correlation
-could occur through timing analysis of messages across the client-facing
-server, or via examining the contents of messages sent between client-facing
-and backend servers. The exact mechanism for preventing this sort of
-correlation is out of scope for this document.
+for Split Mode in particular, ECH makes two additional assumptions:
+
+1. The channel between the client-facing and backend server is authenticated
+such that the backend server only accepts messages from trusted client-facing
+servers. The exact mechanism for establishing this authenticated channel is
+out of scope for this document.
+1. The attacker cannot correlate messages between client and client-facing
+server with messages between client-facing and backend server. Such correlation
+could allow an attacker to link information unique to a backend server, such as
+their server name or IP address, with a client's encrypted ClientHelloInner.
+Correlation could occur through timing analysis of messages across the
+client-facing server, or via examining the contents of messages sent between
+client-facing and backend servers. The exact mechanism for preventing this sort
+of correlation is out of scope for this document.
 
 Given this threat model, the primary goals of ECH are as follows.
 

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1206,7 +1206,7 @@ between the client and client-facing server, as well as between the
 client-facing and backend servers when running ECH in Split Mode. However,
 for Split Mode in particular, ECH makes two additional assumptions:
 
-1. The channel between the client-facing and backend server is authenticated
+1. The channel between each client-facing and each backend server is authenticated
 such that the backend server only accepts messages from trusted client-facing
 servers. The exact mechanism for establishing this authenticated channel is
 out of scope for this document.

--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -161,6 +161,9 @@ the "client-facing server" and to the TLS terminator as the "backend server".
 These are the same entity in Shared Mode, but in Split Mode, the client-facing
 and backend servers are physically separated.
 
+See {{security-considerations}} for more discussion about the ECH threat model
+and how it relates to the client, client-facing server, and backend server.
+
 ## Encrypted ClientHello (ECH)
 
 A client-facing server enables ECH by publishing an ECH configuration, which
@@ -1197,7 +1200,20 @@ such as interfering with existing connections, probing servers, and querying
 DNS. In short, an active attacker corresponds to the conventional threat model
 for TLS 1.3 {{RFC8446}}.
 
-Given these types of attackers, the primary goals of ECH are as follows.
+Passive and active attackers can exist anywhere in the network, including
+between the client and client-facing server, as well as between the
+client-facing and backend servers when running ECH in Split Mode. However,
+for Split Mode in particular, ECH assumes that the attacker cannot correlate
+messages between client and client-facing server with messages between
+client-facing and backend server. Such correlation could allow an attacker
+to link information unique to a backend server, such as their server name
+or IP address, with a client's encrypted ClientHelloInner. Such correlation
+could occur through timing analysis of messages across the client-facing
+server, or via examining the contents of messages sent between client-facing
+and backend servers. The exact mechanism for preventing this sort of
+correlation is out of scope for this document.
+
+Given this threat model, the primary goals of ECH are as follows.
 
 1. Security preservation. Use of ECH does not weaken the security properties of
    TLS without ECH.


### PR DESCRIPTION
Closes #513 
Closes #544 

The intent here is to punt entirely on the mechanism by which messages between client-facing and backend servers are protected in transit, and simply to state the assumption that these messages do not let the attacker trivially learn information that ECH otherwise protects via encryption. Suggestions for further clarifications are welcome!

cc @dennisjackson, @davidben, @cjpatton 