### PR TITLE
Avoid a normative reference to WHATWG-IPV4

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -290,12 +290,12 @@ as described in {{rejected-ech}}.
 
 : Clients MUST ignore any `ECHConfig` structure whose public_name is not
 parsable as a dot-separated sequence of LDH labels, as defined in
-{{!RFC5890, Section 2.3.1}} or which begins or end with an ASCII dot.
-
-: Clients SHOULD ignore the `ECHConfig` if it contains an encoded IPv4 address.
-To determine if a public_name value is an IPv4 address, clients can invoke the
-IPv4 parser algorithm in {{WHATWG-IPV4}}. It returns a value when the input is
-an IPv4 address.
+{{!RFC5890, Section 2.3.1}} or which begins or end with an ASCII dot. Clients
+additionally SHOULD ignore the structure if the final LDH label either consists
+of all ASCII digits (i.e. '0' through '9') or is "0x" or "0X" followed by some,
+possibly empty, sequence of ASCII hexadecimal digits (i.e. '0' through '9', 'a'
+through 'f', and 'A' through 'F'). Thus avoids public_name values that may be
+interpreted as IPv4 literals.
 
 : See {{auth-public-name}} for how the client interprets and validates the
 public_name.
@@ -309,7 +309,6 @@ order. ECHConfigExtension values are described below ({{config-extensions}}).
 
 [[OPEN ISSUE: determine if clients should enforce a 63-octet label limit for
 public_name]]
-[[OPEN ISSUE: fix reference to WHATWG-IPV4]]
 
 The `HpkeKeyConfig` structure contains the following fields:
 
@@ -900,8 +899,8 @@ In verifying the client-facing server certificate, the client MUST interpret
 the public name as a DNS-based reference identity. Clients that incorporate DNS
 names and IP addresses into the same syntax (e.g. {{?RFC3986, Section 7.4}} and
 {{WHATWG-IPV4}}) MUST reject names that would be interpreted as IPv4 addresses.
-Clients that enforce this by checking and rejecting encoded IPv4 addresses
-in ECHConfig.contents.public_name do not need to repeat the check at this layer.
+Clients that enforce this by checking ECHConfig.contents.public_name do not need
+to repeat the check at this layer.
 
 Note that authenticating a connection for the public name does not authenticate
 it for the origin. The TLS implementation MUST NOT report such connections as


### PR DESCRIPTION
DNS names and IPv4 literals are a bit of a mess. RFC 1738 said:

> The rightmost domain label will never start with a digit, though,
> which syntactically distinguishes all domain names from the IP
> addresses.

This is sensible, but was replaced by RFC 3986 with a "first-match-wins" algorithm:

> If host matches the rule for IPv4address, then it should be
> considered an IPv4 address literal and not a reg-name.

The WHATWG URL spec originally mirrored this, but with a *much* more permissive IPv4 parser, to reflect reality. ECH originally cited this, to be sure we don't accidentally mix up IPv4 literals and DNS names.

The change in RFC 3986 was a mistake and introduced a security problem. The RFC 1738 formulation said a.1.2.3.4 was a syntax error, neither a DNS name nor IPv4 literal. The RFC 3986, along with the analog copied into WHATWG, says it's a DNS name because the IPv4 parser rejects it. But this means:

- a.1.2.3.4 is a DNS name
- 1.2.3.4 is an IPv4 literal

See also https://github.com/whatwg/url/issues/560

This means DNS names are no longer closed under suffixes! This causes problems for any systems (e.g. eTLD+1s) that need to suffix a DNS name. WHATWG since effectively reverted the RFC 3986 mistake. After https://github.com/whatwg/url/commit/ab0e820b0b559610b30c731b7f2c1a8094181680, the rule in WHATWG is: if it ends in a number (all digits, or 0x + all hex), parse as an IPv4 literal. Otherwise it's a DNS name.

This rule is finally simple enough that we can just lift it into ECH.

(If we want, we can simplify this by just reverting to the RFC 1738 formulation, which should be safe in this context. It is a pity RFC 3986 made a mess here.)