### PR TITLE
Define ECHConfigExtensionType before referencing it.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -216,9 +216,10 @@ The ECH configuration is defined by the following `ECHConfig` structure.
 
 ~~~~
     opaque HpkePublicKey<1..2^16-1>;
-    uint16 HpkeKemId;  // Defined in RFC9180
-    uint16 HpkeKdfId;  // Defined in RFC9180
-    uint16 HpkeAeadId; // Defined in RFC9180
+    uint16 HpkeKemId;              // Defined in RFC9180
+    uint16 HpkeKdfId;              // Defined in RFC9180
+    uint16 HpkeAeadId;             // Defined in RFC9180
+    uint16 ECHConfigExtensionType; // Defined in {{config-extensions-iana}}
 
     struct {
         HpkeKdfId kdf_id;


### PR DESCRIPTION
Everything else in the definition is defined before being referenced. The only other details on this field occur pretty far into the doc, so I thought it'd be nice to define it with a pointer to the relevant section with more details