### PR TITLE
Proposed changes to the overview section to give better justice to ECH.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -118,11 +118,36 @@ notation comes from {{RFC8446, Section 3}}.
 
 # Overview
 
+ECH is a protocol extension to TLS1.3 which objective is to encrypt the
+ClientHello to fulfill a number of goals (see {{goals}}), in particular
+hiding the destination and therefore the Server Name Indication (SNI).
+
+In order to fulfill these goals ECH introduced and relies on a number
+of key design ideas:
+
+* A new ClientHello message: the ClientHello message is defined now as
+a non-encrypted ClientHello "outer" which encapsulates an encrypted
+ClientHello "inner",
+* A new cryptography: the encryption is performed using a new cryptography
+called Hybrid Public Key Encrpytion (HPKE) (see {{!HPKE=RFC9180}}),
+* New origin server roles: the origin servers are now defined as two roles:
+a) a Client-Facing server role and b) a Backend Server role
+(see {{topologies}}),
+* An ECH configuration: the Client-Facing server is responsible to produce
+the ECH configuration (see {{ech-configuration}}) including the HPKE
+public key and metadata,
+* ECH configuration delivery mechanisms: the ECH configuration can
+be shared by different delivery mechanisms in particular the DNS
+leveraging new service bindings,
+* A real ECH and GREASE ECH modes: the client offers a real ECH if
+it is in possession of a compatible ECH configuration and sends GREASE
+ECH otherwise (see {{dont-stick-out}}).
+
+## Topologies {#topologies}
+
 This protocol is designed to operate in one of two topologies illustrated below,
 which we call "Shared Mode" and "Split Mode". These modes are described in the
 following section.
-
-## Topologies
 
 ~~~~
                 +---------------------+


### PR DESCRIPTION
Currently the overview section is a sentence that is actually not giving an overview of the protocol. The sentence is simply the highlight for the topologies sub-section. But the topologies sub-section is not a protocol overview. ECH is much more than just a topology. 

The proposal is to give justice to ECH and improve the overview section. 

As I am both coming at a very late state of the development of this text and this is the first time I do this review I contemplate that there could be more options. 

For example the first part of my text is a bit redundant with some of the text in the introduction, calling for whether my proposal should be moved to introductions or to rearrange the sections. 

Yet, there is no where in the text a description on all the key design ideas and maybe my selection could be completed by more ideas, e.g. list DoH and DPRIVE too in this list, which will then be calling to overlaps with introduction section.

Anyway, this is my current proposal because right now, the overview is not giving justice nor anywhere in the text to ECH.
