### PR TITLE
Experimental proposal to add an Abbreviation section ommitting 'well …

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -116,6 +116,73 @@ document are to be interpreted as described in BCP 14 {{RFC2119}} {{!RFC8174}}
 when, and only when, they appear in all capitals, as shown here. All TLS
 notation comes from {{RFC8446, Section 3}}.
 
+# Abbreviations
+
+
+This section expands abbreviations that are not 'well known' as per RFC Editors
+abbreviations list.
+
+AAD
+: Additional Authenticated Data
+: Associated Authenticated Data
+
+AEAD
+: Authenticated Encryption with Associated Data
+
+ALPN
+: Application-Layer Protocol Negotiation
+
+CA
+: Certificate Authority
+
+CH
+: Client Hello
+
+CRL
+: Certificate Revocation List
+
+DoH
+: DNS over HTTP
+
+DPRIVE
+: DNS PRIVate Exchange
+
+DTLS
+: Datagram Transport Layer Security
+
+ECH
+: Encrypted Client Hello
+
+EE
+: Encrypted Extensions
+
+KDF
+: Key Derivation Function
+
+KEM
+: Key Encapsulation Mechanism
+
+HPKE
+: Hybrid Public Key Encryption
+
+HRR
+: Hello Retry Request
+
+HTTPS-RR
+: HTTPS Resource Record
+
+OCSP
+: Online Certificate Status Protocol
+
+PSK
+: Pre Shared Key
+
+RR
+: Resource Record
+
+SNI
+: Server Name Indication
+
 # Overview
 
 This protocol is designed to operate in one of two topologies illustrated below,


### PR DESCRIPTION
…known' ones.

So this one is an experimental proposal because indeed I couldn't see many Abbreviation sections in any RFCs. 
I found an abbreviation list from 'Editors' but it stops being updated in 2021 (wondering the story behind this one).
But I liked the concept of well known abbreviations vs not well known ones. 

In general when I read a text and moreover a complicated text, I hate to have to guess what means acronym A, B, C and or to have my brain to 'calculate' on the fly what it is or to have to research in another document. In my mind, it is 'basic respect' to the reader to put the acronym in plain. 

OF COURSE I do understand that for developers these are completely obvious. I get that. But for Operational people or other persona, sorry, I am not coding TLS every day so I made a mistake to understand HRR or EE and for example AAD has two meanings ... which is calling why we might want to put more definitions (See my other PR on definitions).

Anyway we can debate if X or Y or Z is well known or not but I think there are too many new things in this one and an Abbreviation section would help.

As said in IETF 118, ECH is complex, so am trying to help a little bit on that line, but if nobody happy with it, just reject it.
