### PR TITLE
A first proposal to fix the no-sni section.

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -1242,18 +1242,11 @@ Depending on implementation details and deployment settings, use cases
 which depend on plaintext TLS information may require fundamentally different
 approaches to continue working. For example, in managed enterprise settings,
 one approach may be to disable ECH entirely via group policy and for
-client implementations to honor this action. Another approach may be to
+client implementations to honor this action.
+
+In the context of {{rejected-ech}}, another approach may be to
 intercept and decrypt client TLS connections. The feasibility of alternative
 solutions is specific to individual deployments.
-
-In environments where the network operator does not control the endpoint
-devices, or does controls the endpoint devices but is concerned about the
-security consequences of compromised devices, e.g., data exfiltration, the
-SNI field is unsuitable for use as a control even in the absence of ECH. This
-is because devices without controls, or which have been compromised, can alter
-or spoof the value in an SNI field already, and can even bypass security
-appliances which try to 'double-check' websites hosted by the target server.
-ECH does not materially change this situation.
 
 # Compliance Requirements {#compliance}
 


### PR DESCRIPTION
In this part of the text there would be a lot to say.

First for non-English native speakers who are not familiar with the topic and in particular in operations or even to some degree in system architecture or network security domains, the text will be very difficult to read.

In fact think about someone in a Small and Medium Enterprises organization that has to ensure the security of its organization it will be close to impossible to connect the dots. How many dozen of millions of SMEs on the planet?

Anyway, it is VERY hard to be more explicit in the context of this draft though I would be tempted to add examples and be more explicit on sub-contexts and on use cases e.g. put in hard BYOD will fail. but anyway this links to OUR Internet Draft on Deployment Considerations that suddenly makes a lot of sense as an expansion of this section from 1 page to 20+.

One could argue that there are many types of Middleboxes and they all will be affected by that (DPI, Firewalls, Proxies, etc.)

However there is ONE section which is simply 1) wrong and 2) completely irrelevant is the last section which I removed. The only alternative would be to make a significant fix in that section and even if I fix it, it will add nothing to the fact that when a number of devices won't be able to access the SNI, they will break, period.

So I am happy to rework a section but the section will say that whilst in general the SNI is unreliable, in practice there are essential sub-context where is is not only VERY reliable but as well is a very valuable information for in-path actors who have many ways to check and validate and handle the unreliable part.