### PR TITLE
Correct `ECHConfigList` length bounds

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -335,7 +335,7 @@ The client-facing server advertises a sequence of ECH configurations to clients,
 serialized as follows.
 
 ~~~~
-    ECHConfig ECHConfigList<1..2^16-1>;
+    ECHConfig ECHConfigList<4..2^16-1>;
 ~~~~
 
 The `ECHConfigList` structure contains one or more `ECHConfig` structures in


### PR DESCRIPTION
Draft 18.

`ECHConfig` is:

```
       struct {
           uint16 version;
           uint16 length;
           select (ECHConfig.version) {
             case 0xfe0d: ECHConfigContents contents;
           }
       } ECHConfig;
```

4 bytes each minimum.

`ECHConfigList` is:

```
       ECHConfig ECHConfigList<1..2^16-1>;
```

That implies an `ECHConfig` could be encoded in one byte? I think this should be:

```
       ECHConfig ECHConfigList<4..2^16-4>;
```