### PR TITLE
remove disclaimer

### DIFF
--- a/draft-ietf-tls-esni.md
+++ b/draft-ietf-tls-esni.md
@@ -73,11 +73,6 @@ encrypting a ClientHello message under a server public key.
 
 # Introduction {#intro}
 
-DISCLAIMER: This draft is work-in-progress and has not yet seen significant (or
-really any) security analysis. It should not be used as a basis for building
-production systems. This published version of the draft has been designated
-an "implementation draft" for testing and interop purposes.
-
 Although TLS 1.3 {{!RFC8446}} encrypts most of the handshake, including the
 server certificate, there are several ways in which an on-path attacker can
 learn private information about the connection. The plaintext Server Name


### PR DESCRIPTION
Since there has been security review and modeling of ECH it seems it would be appropriate to remove this disclaimer. 