### PR TITLE
AUTH48 polish: typos and small clarity fixes (no RFC placeholder expansions)

### DIFF
--- a/rfc9849.md
+++ b/rfc9849.md
@@ -553,7 +553,7 @@ into an `EncodedClientHelloInner` structure, defined below:
 The `client_hello` field is computed by first making a copy of `ClientHelloInner`
 and setting the `legacy_session_id` field to the empty string. In TLS, this
 field uses the `ClientHello` structure defined in {{Section 4.1.2 of RFC8446}}.
-In DTLS, it uses the `ClientHello` structured defined in
+In DTLS, it uses the `ClientHello` structure defined in
 {{Section 5.3 of RFC9147}}. This does not include Handshake structure's
 four-byte header in TLS, nor twelve-byte header in DTLS. The `zeros` field MUST
 be all zeroes of length `length_of_padding` (see {{padding}}).
@@ -695,7 +695,7 @@ Next, it constructs a partial `ClientHelloOuterAAD` as it does a standard
    compatibility mode is not used in DTLS 1.3, but following this rule will
    produce the correct results for both TLS 1.3 and DTLS 1.3.
 1. It MAY copy any other field from the `ClientHelloInner` except
-   `ClientHelloInner.random`. Instead, It MUST generate a fresh
+   `ClientHelloInner.random`. Instead, it MUST generate a fresh
    `ClientHelloOuter.random` using a secure random number generator. (See
    {{flow-client-reaction}}.)
 1. It SHOULD place the value of `ECHConfig.contents.public_name` in the
@@ -1135,7 +1135,7 @@ message.  This can be accomplished in several ways, including:
 # Server Behavior {#server-behavior}
 
 As described in {{topologies}}, servers can play two roles, either as
-the client-facing server or as the back-end server.
+the client-facing server or as the backend server.
 Depending on the server role, the `ECHClientHello` will be different:
 
 * A client-facing server expects an `ECHClientHello.type` of `outer`, and
@@ -1709,7 +1709,7 @@ client previously connected to and which is within the same anonymity set.
 {{Section 4.2.2 of RFC8446}} defines a cookie value that servers may send in
 HelloRetryRequest for clients to echo in the second `ClientHello`. While ECH
 encrypts the cookie in the second `ClientHelloInner`, the backend server's
-HelloRetryRequest is unencrypted.This means differences in cookies between
+HelloRetryRequest is unencrypted. This means differences in cookies between
 backend servers, such as lengths or cleartext components, may leak information
 about the server identity.
 
@@ -2091,9 +2091,9 @@ Extension Name:
 : Name of the ECHConfigExtension
 
 Recommended:
-: A "Y" or "N" value indicating if the extension is TLS WG recommends that the
+: A "Y" or "N" value indicating if the TLS Working Group recommends that the
 extension be supported. This column is assigned a value of "N" unless
-explicitly requested. Adding a value with a value of "Y" requires Standards
+explicitly requested. Adding a value of "Y" requires Standards
 Action {{RFC8126}}.
 
 Reference:


### PR DESCRIPTION
## Summary

1. Fix typo: `structured defined` → `structure defined`
2. Fix capitalization: `Instead, It MUST` → `Instead, it MUST`
3. Terminology consistency: `back-end server` → `backend server`
4. Fix missing space: `unencrypted.This` → `unencrypted. This`
5. Fix grammar in IANA registry `Recommended` field description

**This PR does not expand or modify any RFC number placeholders (e.g., RFCYYY1).**