### PR TITLE
[AUTH48] kazuho reviews

### DIFF
--- a/rfc9849.md
+++ b/rfc9849.md
@@ -490,7 +490,7 @@ fields:
 
 `cipher_suite`:
 : The cipher suite used to encrypt `ClientHelloInner`. This MUST match a value
-provided in the corresponding `ECHConfigContents.cipher_suites` list.
+provided in the corresponding `ECHConfigContents.key_config.cipher_suites` list.
 
 enc:
 : The HPKE encapsulated key used by servers to decrypt the corresponding
@@ -650,13 +650,14 @@ if it is in possession of a compatible ECH configuration and sends GREASE ECH
 
 To offer ECH, the client first chooses a suitable `ECHConfig` from the server's
 `ECHConfigList`. To determine if a given `ECHConfig` is suitable, it checks that
-it supports the KEM algorithm identified by `ECHConfig.contents.kem_id`, at
-least one KDF/AEAD algorithm identified by `ECHConfig.contents.cipher_suites`,
-and the version of ECH indicated by `ECHConfig.version`. Once a
-suitable configuration is found, the client selects the cipher suite it will
-use for encryption. It MUST NOT choose a cipher suite or version not advertised
-by the configuration. If no compatible configuration is found, then the client
-SHOULD proceed as described in {{grease-ech}}.
+it supports the KEM algorithm identified by
+`ECHConfig.contents.key_config.kem_id`, at least one KDF/AEAD algorithm
+identified by `ECHConfig.contents.key_config.cipher_suites`, and the version of
+ECH indicated by `ECHConfig.version`. Once a suitable configuration is found,
+the client selects the cipher suite it will use for encryption. It MUST NOT
+choose a cipher suite or version not advertised by the configuration. If no
+compatible configuration is found, then the client SHOULD proceed as described
+in {{grease-ech}}.
 
 Next, the client constructs the `ClientHelloInner` message just as it does a
 standard `ClientHello`, with the exception of the following rules:
@@ -677,7 +678,7 @@ The client then constructs `EncodedClientHelloInner` as described in
 as:
 
 ~~~
-    pkR = DeserializePublicKey(ECHConfig.contents.public_key)
+    pkR = DeserializePublicKey(ECHConfig.contents.key_config.public_key)
     enc, context = SetupBaseS(pkR,
                               "tls ech" || 0x00 || ECHConfig)
 ~~~

--- a/rfc9849.md
+++ b/rfc9849.md
@@ -24,8 +24,9 @@ author:
        org: Independent
        email: ekr@rtfm.com
 
- -     name: Kazuho Oku
-       ins: K. Oku
+ -     fullname:
+         :: 奥 一穂
+         ascii: Kazuho Oku
        org: Fastly
        email: kazuhooku@gmail.com
 


### PR DESCRIPTION
This pull request proposes 2 changes:
* Fix incorrect references in Section 5 and 6.1. `cipher_suites`, `kem_id`, `public_key` are properties of `HpkeKeyConfig`, and therefore should be referred to as `ECHConfigContents.**key_config**.~`.
* Use Kanji for representing Kazuho's name, as is done in other RFCs.